### PR TITLE
converting to local package import framework using setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,14 @@ line_length = 88
 include_trailing_comma = true
 multi_line_output = 3
 known_first_party= ["cionic", "kinematics"]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cionic"
+version = "0.1.0"
+
+[tool.setuptools]
+packages = ["cionic"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,7 +13,7 @@ You will first need to download an authorization token from the web portal.
 
 ## Setup
 
-The scripts depend on the following python packages:
+The scripts depend on the following third party python packages:
 
 ```
 numpy==1.23.4
@@ -36,6 +36,11 @@ Activate the virtual environment:
 Install packages:
 
 `pip3 install -r scripts/requirements.txt`
+
+Creates a local package from source code:
+
+`python3 -m pip install --upgrade pip`
+`pip install -e .`
 
 ## download.py
 

--- a/scripts/auth.py
+++ b/scripts/auth.py
@@ -3,7 +3,6 @@
 import argparse
 import sys
 
-sys.path.append('.')
 import cionic
 
 __usage__ = '''

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -7,11 +7,12 @@ import sys
 
 import pandas as pd
 
-sys.path.append('.')
 import cionic
 
 __usage__ = '''
-./scripts/download.py [orgid] [studyid]
+./scripts/download.py
+    [orgid]
+    [studyid]
     [-n <collection numbers to download>]
     [-c <streams to csv>]
     [-o <output directory>]


### PR DESCRIPTION
## What it is

Use [setuptools](https://setuptools.pypa.io/en/latest/userguide/quickstart.html) to create a local `cionic` package from the `cionic/` directory source code. This will be used by scripts. The package is editable, so any changes to the source code will be immediately reflected upon import.

## How I tested it

Tear down and rebuild the environment:
`deactivate && rm -rf venv && ls -la` (careful with `rm -rf`, obviously)
`python3 -m venv venv && source venv/bin/activate && pip3 install -r scripts/requirements.txt && pip freeze`

Create the package: 
`python3 -m pip install --upgrade pip`
`pip install -e .`

Verify `download.py` works, e.g.:
`python ./scripts/download.py cionic CSU_Normative -n 254 -c emg fquat`