### PR TITLE
adding a gait metrics suite

### DIFF
--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -430,7 +430,7 @@ def compute_swing_std_value(
 
 @dataclass
 class Metadata:
-    position: int
+    position: str
     stream_name: str
     component: str
     orgid: Optional[str] = None

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -69,12 +69,30 @@ class Metric(Enum):
 
 
 def compute_stride_time(stride_data: np.ndarray) -> float:
+    """
+    Compute the stride time for the given stride data.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+
+    Returns:
+        float: Duration of the stride, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return stride_data['elapsed_s'].max() - stride_data['elapsed_s'].min()
 
 
 def compute_cadence(stride_data: np.ndarray) -> float:
+    """
+    Compute cadence (steps per minute) for the stride data.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+
+    Returns:
+        float: Cadence value, or None if data is empty or duration is zero.
+    """
     if stride_data.shape[0] == 0:
         return None
     duration = compute_stride_time(stride_data)
@@ -84,12 +102,32 @@ def compute_cadence(stride_data: np.ndarray) -> float:
 
 
 def compute_peak_value(stride_data: np.ndarray, component: str = 'x') -> float:
+    """
+    Compute the peak value of a component during the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Peak value, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].max()
 
 
 def compute_trough_value(stride_data: np.ndarray, component: str = 'x') -> float:
+    """
+    Compute the trough value of a component during the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Trough value, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].min()
@@ -98,6 +136,16 @@ def compute_trough_value(stride_data: np.ndarray, component: str = 'x') -> float
 def compute_start_heel_strike_value(
     stride_data: np.ndarray, component: str = 'x'
 ) -> float:
+    """
+    Get the value of a component at the start of the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Value at start, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return stride_data[0][component]
@@ -106,24 +154,64 @@ def compute_start_heel_strike_value(
 def compute_stop_heel_strike_value(
     stride_data: np.ndarray, component: str = 'x'
 ) -> float:
+    """
+    Get the value of a component at the end of the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Value at end, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return stride_data[-1][component]
 
 
 def compute_mean_value(stride_data: np.ndarray, component: str = 'x') -> float:
+    """
+    Compute the mean value of a component during the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Mean value, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].mean()
 
 
 def compute_median_value(stride_data: np.ndarray, component: str = 'x') -> float:
+    """
+    Compute the median value of a component during the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Median value, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return np.median(stride_data[component])
 
 
 def compute_std_value(stride_data: np.ndarray, component: str = 'x') -> float:
+    """
+    Compute the standard deviation of a component during the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Standard deviation, or None if data is empty.
+    """
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].std()
@@ -132,6 +220,17 @@ def compute_std_value(stride_data: np.ndarray, component: str = 'x') -> float:
 def compute_toe_off_value(
     stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
 ) -> float:
+    """
+    Get the value of a component at the toe off time.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Value at toe off, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     closest_index = np.abs(stride_data['elapsed_s'] - toe_off_time).argmin()
@@ -141,6 +240,16 @@ def compute_toe_off_value(
 def compute_stance_time(
     stride_data: np.ndarray, toe_off_time: Optional[float]
 ) -> float:
+    """
+    Compute the duration of the stance phase for the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+
+    Returns:
+        float: Stance duration, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     return toe_off_time - stride_data['elapsed_s'].min()
@@ -149,6 +258,17 @@ def compute_stance_time(
 def compute_stance_mean_value(
     stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
 ) -> float:
+    """
+    Compute mean value of a component during the stance phase.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Mean value, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
@@ -160,6 +280,17 @@ def compute_stance_mean_value(
 def compute_stance_median_value(
     stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
 ) -> float:
+    """
+    Compute median value of a component during the stance phase.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Median value, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
@@ -171,6 +302,17 @@ def compute_stance_median_value(
 def compute_stance_std_value(
     stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
 ) -> float:
+    """
+    Compute standard deviation of a component during the stance phase.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Standard deviation, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
@@ -180,6 +322,16 @@ def compute_stance_std_value(
 
 
 def compute_swing_time(stride_data: np.ndarray, toe_off_time: Optional[float]) -> float:
+    """
+    Compute the duration of the swing phase for the stride.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+
+    Returns:
+        float: Swing duration, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     return stride_data['elapsed_s'].max() - toe_off_time
@@ -188,6 +340,17 @@ def compute_swing_time(stride_data: np.ndarray, toe_off_time: Optional[float]) -
 def compute_swing_mean_value(
     stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
 ) -> float:
+    """
+    Compute mean value of a component during the swing phase.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Mean value, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
@@ -199,6 +362,17 @@ def compute_swing_mean_value(
 def compute_swing_median_value(
     stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
 ) -> float:
+    """
+    Compute median value of a component during the swing phase.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Median value, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
@@ -210,6 +384,17 @@ def compute_swing_median_value(
 def compute_swing_std_value(
     stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
 ) -> float:
+    """
+    Compute standard deviation of a component during the swing phase.
+
+    Args:
+        stride_data (np.ndarray): Array of stride data.
+        toe_off_time (float): Toe off timestamp.
+        component (str): Component name to analyze.
+
+    Returns:
+        float: Standard deviation, or None if data is empty or time is None.
+    """
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
@@ -237,6 +422,16 @@ class GaitMetricsCalculator:
         toe_off_times: Optional[np.ndarray] = None,
         shank_stream: Optional[np.ndarray] = None,
     ) -> None:
+        """
+        Initialize the GaitMetricsCalculator with input data and metadata.
+
+        Args:
+            stream (np.ndarray): Kinematics input data.
+            stride_splits (np.ndarray): Array of stride splits.
+            meta (Metadata): Metadata for analysis.
+            toe_off_times (np.ndarray, optional): Toe off timestamps.
+            shank_stream (np.ndarray, optional): Shank stream data.
+        """
         self.stream = stream
         self.stride_splits = stride_splits
         self.meta = meta
@@ -248,6 +443,15 @@ class GaitMetricsCalculator:
             self.toe_off_times = None
 
     def compute_toe_offs(self, shank_stream: np.ndarray) -> np.ndarray:
+        """
+        Compute toe off times from shank stream data.
+
+        Args:
+            shank_stream (np.ndarray): Shank stream data.
+
+        Returns:
+            np.ndarray: Array of toe off timestamps.
+        """
         grouped_toe_off_times = kinematics.get_grouped_walking_splits(
             shank_stream, factor=-1.0
         )
@@ -255,6 +459,15 @@ class GaitMetricsCalculator:
         return np.array(toe_off_times)
 
     def get_toe_off_time(self, stride_data: np.ndarray) -> Optional[float]:
+        """
+        Get the toe off time within the stride data range.
+
+        Args:
+            stride_data (np.ndarray): Array of stride data.
+
+        Returns:
+            float: Toe off timestamp, or None if not found.
+        """
         if self.toe_off_times is None:
             return None
         # Find the toe off time falling in the time range of the stride
@@ -272,6 +485,16 @@ class GaitMetricsCalculator:
         metrics: Optional[list[Metric]] = None,
         output_path: Optional[str] = None,
     ) -> pd.DataFrame:
+        """
+        Calculate selected gait metrics for all strides and save to CSV if needed.
+
+        Args:
+            metrics (list[Metric], optional): Metrics to compute.
+            output_path (str, optional): Output directory path.
+
+        Returns:
+            pd.DataFrame: DataFrame of computed metrics for all strides.
+        """
         if metrics is None:
             metrics = list(Metric)
 
@@ -405,6 +628,26 @@ def compute_gait_metrics(
     metrics: Optional[list[Metric]] = None,
     output_path: Optional[str] = None,
 ) -> pd.DataFrame:
+    """
+    Compute gait metrics for all strides and save to CSV if output_path is given.
+
+    Args:
+        stream (np.ndarray): Kinematics input data.
+        stride_splits (np.ndarray): Array of stride splits.
+        position (int): Position identifier, e.g. 'r_shank'
+        stream_name (str): Name of the stream.
+        component (str): Component to analyze, e.g. 'x', 'knee_flexion'.
+        orgid (str, optional): Organization ID.
+        study (str, optional): Study name.
+        collection_num (int, optional): Collection number.
+        toe_off_times (np.ndarray, optional): Toe off timestamps.
+        shank_stream (np.ndarray, optional): Shank stream data.
+        metrics (list[Metric], optional): Metrics to compute.
+        output_path (str, optional): Output directory path.
+
+    Returns:
+        pd.DataFrame: DataFrame of computed metrics for all strides.
+    """
     metrics_calculator = GaitMetricsCalculator(
         stream=stream,
         stride_splits=stride_splits,

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -638,7 +638,7 @@ class GaitMetricsCalculator:
                         stride_data, toe_off_time, self.meta.component
                     )
             all_strides_metrics_list.append(stride_metrics)
-            break
+
         all_strides_metrics = pd.DataFrame(all_strides_metrics_list)
         if output_path is not None:
             self._output_metrics_to_csv(all_strides_metrics, output_path)

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -262,9 +262,11 @@ class GaitMetricsCalculator:
                 & (self.stream['elapsed_s'] <= stop_s)
             ]
 
+            stride_metrics = {metric.value: None for metric in metrics}
             stride_metrics = {
-                metric.value: None for metric in metrics
-            }  # TODO: decide on this or initialize with {}
+                **{'start_s': start_s, 'stop_s': stop_s},
+                **stride_metrics,
+            }
 
             toe_off_time = self.get_toe_off_time(stride_data)
             for metric in metrics:
@@ -363,3 +365,36 @@ class GaitMetricsCalculator:
                 os.makedirs(output_path)
             all_strides_metrics.to_csv(file_path, index=True)
         return all_strides_metrics
+
+
+def compute_gait_metrics(
+    stream,
+    stride_splits,
+    position,
+    stream_name,
+    component,
+    orgid=None,
+    study=None,
+    collection_num=None,
+    toe_off_times=None,
+    shank_stream=None,
+    metrics=None,
+    output_path=None,
+):
+    metrics_calculator = GaitMetricsCalculator(
+        stream=stream,
+        stride_splits=stride_splits,
+        meta=Metadata(
+            position=position,
+            stream_name=stream_name,
+            component=component,
+            orgid=orgid,
+            study=study,
+            collection_num=collection_num,
+        ),
+        toe_off_times=toe_off_times,
+        shank_stream=shank_stream,
+    )
+    return metrics_calculator.calculate_metrics(
+        metrics=metrics, output_path=output_path
+    )

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -39,6 +39,7 @@ Metrics:
 import os
 from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
 import numpy as np
 import pandas as pd
@@ -199,12 +200,12 @@ def compute_swing_std_value(stride_data, toe_off_time, component='x'):
 
 @dataclass
 class Metadata:
-    orgid: str
-    study: str
-    collection_num: int
     position: int
     stream_name: str
     component: str
+    orgid: Optional[str] = None
+    study: Optional[str] = None
+    collection_num: Optional[int] = None
 
 
 class GaitMetricsCalculator:
@@ -339,13 +340,26 @@ class GaitMetricsCalculator:
             all_strides_metrics_list.append(stride_metrics)
         all_strides_metrics = pd.DataFrame(all_strides_metrics_list)
         if output_path is not None:
+
+            if self.meta.orgid and self.meta.study and self.meta.collection_num:
+                output_path = os.path.join(
+                    output_path,
+                    self.meta.orgid,
+                    self.meta.study,
+                    str(self.meta.collection_num),
+                )
+                file_path = (
+                    f"{output_path}/{self.meta.orgid}_"
+                    f"{self.meta.study}_{self.meta.collection_num}_"
+                    f"{self.meta.position}_{self.meta.stream_name}_"
+                    f"{self.meta.component}_gait_metrics.csv"
+                )
+            else:
+                file_path = (
+                    f"{output_path}/{self.meta.position}_{self.meta.stream_name}_"
+                    f"{self.meta.component}_gait_metrics.csv"
+                )
             if not os.path.exists(output_path):
                 os.makedirs(output_path)
-            file_path = (
-                f"{output_path}/{self.meta.orgid}_"
-                f"{self.meta.study}_{self.meta.collection_num}_"
-                f"{self.meta.position}_{self.meta.stream_name}_"
-                f"{self.meta.component}_gait_metrics.csv"
-            )
             all_strides_metrics.to_csv(file_path, index=True)
         return all_strides_metrics

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -450,6 +450,9 @@ class GaitMetricsCalculator:
         """
         Initialize the GaitMetricsCalculator with input data and metadata.
 
+        If toe_off_times are not provided, they will be computed from the shank_stream
+        if available.
+
         Args:
             stream (np.ndarray): Kinematics input data.
             stride_splits (np.ndarray): Array of stride splits.

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -555,21 +555,16 @@ class GaitMetricsCalculator:
         all_strides_metrics_list = []
         for stride in self.stride_splits:
             # Extract relevant data for the current stride
-            start_s = stride['start_s']
-            stop_s = stride['stop_s']
-
             stride_data = self.stream[
-                (self.stream['elapsed_s'] >= start_s)
-                & (self.stream['elapsed_s'] <= stop_s)
+                (self.stream['elapsed_s'] >= stride['start_s'])
+                & (self.stream['elapsed_s'] <= stride['stop_s'])
             ]
-
-            stride_metrics = {metric.value: None for metric in metrics}
-            stride_metrics = {
-                **{'start_s': start_s, 'stop_s': stop_s},
-                **stride_metrics,
-            }
-
             toe_off_time = self._get_toe_off_time(stride_data)
+
+            stride_metrics = {
+                **{'start_s': stride['start_s'], 'stop_s': stride['stop_s']},
+                **{metric.value: None for metric in metrics},
+            }
             for metric in metrics:
                 if metric == Metric.STRIDE_TIME:
                     stride_metrics[metric.value] = compute_stride_time(stride_data)
@@ -639,7 +634,6 @@ class GaitMetricsCalculator:
                     stride_metrics[metric.value] = compute_swing_std_value(
                         stride_data, toe_off_time, self.meta.component
                     )
-
             all_strides_metrics_list.append(stride_metrics)
         all_strides_metrics = pd.DataFrame(all_strides_metrics_list)
         if output_path is not None:

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -438,11 +438,11 @@ class GaitMetricsCalculator:
         if toe_off_times is not None:
             self.toe_off_times = toe_off_times
         elif shank_stream is not None:
-            self.toe_off_times = self.compute_toe_offs(shank_stream)
+            self.toe_off_times = self._compute_toe_offs(shank_stream)
         else:
             self.toe_off_times = None
 
-    def compute_toe_offs(self, shank_stream: np.ndarray) -> np.ndarray:
+    def _compute_toe_offs(self, shank_stream: np.ndarray) -> np.ndarray:
         """
         Compute toe off times from shank stream data.
 
@@ -458,7 +458,7 @@ class GaitMetricsCalculator:
         toe_off_times = [item for sublist in grouped_toe_off_times for item in sublist]
         return np.array(toe_off_times)
 
-    def get_toe_off_time(self, stride_data: np.ndarray) -> Optional[float]:
+    def _get_toe_off_time(self, stride_data: np.ndarray) -> Optional[float]:
         """
         Get the toe off time within the stride data range.
 
@@ -479,6 +479,38 @@ class GaitMetricsCalculator:
             ):
                 return toe_off_time
         return None
+
+    def _output_metrics_to_csv(
+        self, all_strides_metrics: pd.DataFrame, output_path: str
+    ) -> None:
+        """
+        Output the computed metrics DataFrame to a CSV file.
+
+        Args:
+            all_strides_metrics (pd.DataFrame): DataFrame containing the metrics.
+            output_path (str): Path to the output CSV file.
+        """
+        if self.meta.orgid and self.meta.study and self.meta.collection_num:
+            output_path = os.path.join(
+                output_path,
+                self.meta.orgid,
+                self.meta.study,
+                str(self.meta.collection_num),
+            )
+            file_path = (
+                f"{output_path}/{self.meta.orgid}_"
+                f"{self.meta.study}_{self.meta.collection_num}_"
+                f"{self.meta.position}_{self.meta.stream_name}_"
+                f"{self.meta.component}_gait_metrics.csv"
+            )
+        else:
+            file_path = (
+                f"{output_path}/{self.meta.position}_{self.meta.stream_name}_"
+                f"{self.meta.component}_gait_metrics.csv"
+            )
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+        all_strides_metrics.to_csv(file_path, index=True)
 
     def calculate_metrics(
         self,
@@ -515,7 +547,7 @@ class GaitMetricsCalculator:
                 **stride_metrics,
             }
 
-            toe_off_time = self.get_toe_off_time(stride_data)
+            toe_off_time = self._get_toe_off_time(stride_data)
             for metric in metrics:
                 if metric == Metric.STRIDE_TIME:
                     stride_metrics[metric.value] = compute_stride_time(stride_data)
@@ -589,28 +621,8 @@ class GaitMetricsCalculator:
             all_strides_metrics_list.append(stride_metrics)
         all_strides_metrics = pd.DataFrame(all_strides_metrics_list)
         if output_path is not None:
+            self._output_metrics_to_csv(all_strides_metrics, output_path)
 
-            if self.meta.orgid and self.meta.study and self.meta.collection_num:
-                output_path = os.path.join(
-                    output_path,
-                    self.meta.orgid,
-                    self.meta.study,
-                    str(self.meta.collection_num),
-                )
-                file_path = (
-                    f"{output_path}/{self.meta.orgid}_"
-                    f"{self.meta.study}_{self.meta.collection_num}_"
-                    f"{self.meta.position}_{self.meta.stream_name}_"
-                    f"{self.meta.component}_gait_metrics.csv"
-                )
-            else:
-                file_path = (
-                    f"{output_path}/{self.meta.position}_{self.meta.stream_name}_"
-                    f"{self.meta.component}_gait_metrics.csv"
-                )
-            if not os.path.exists(output_path):
-                os.makedirs(output_path)
-            all_strides_metrics.to_csv(file_path, index=True)
         return all_strides_metrics
 
 

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -12,7 +12,10 @@ optional metadata. The module extracts stride segments, computes metrics such as
 stride time, cadence, peak/trough values, and stance/swing phase statistics, and
 saves the results to disk for further analysis.
 
-Usage Example:
+Usage Example (CLI):
+    python3 tests/test_metrics_calculator.py
+
+Usage Example (Code):
 
     metrics_calculator = gait_metrics.GaitMetricsCalculator(
         stream=kinematic_data_stream,
@@ -635,6 +638,7 @@ class GaitMetricsCalculator:
                         stride_data, toe_off_time, self.meta.component
                     )
             all_strides_metrics_list.append(stride_metrics)
+            break
         all_strides_metrics = pd.DataFrame(all_strides_metrics_list)
         if output_path is not None:
             self._output_metrics_to_csv(all_strides_metrics, output_path)

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -72,27 +72,6 @@ import pandas as pd
 from cionic import kinematics
 
 
-class Metric(Enum):
-    STRIDE_TIME = 'stride_time'
-    CADENCE = 'cadence'
-    PEAK_VALUE = 'peak_value'
-    TROUGH_VALUE = 'trough_value'
-    START_HEEL_STRIKE_VALUE = 'start_heel_strike_value'
-    STOP_HEEL_STRIKE_VALUE = 'stop_heel_strike_value'
-    MEAN_VALUE = 'mean_value'
-    MEDIAN_VALUE = 'median_value'
-    STD_VALUE = 'std_value'
-    TOE_OFF_VALUE = 'toe_off_value'
-    STANCE_TIME = 'stance_time'
-    STANCE_MEAN_VALUE = 'stance_mean_value'
-    STANCE_MEDIAN_VALUE = 'stance_median_value'
-    STANCE_STD_VALUE = 'stance_std_value'
-    SWING_TIME = 'swing_time'
-    SWING_MEAN_VALUE = 'swing_mean_value'
-    SWING_MEDIAN_VALUE = 'swing_median_value'
-    SWING_STD_VALUE = 'swing_std_value'
-
-
 def compute_stride_time(stride_data: np.ndarray) -> float:
     """
     Compute the stride time for the given stride data.
@@ -428,6 +407,62 @@ def compute_swing_std_value(
     return compute_std_value(swing_data, component)
 
 
+class Metric(Enum):
+    STRIDE_TIME = 'stride_time'
+    CADENCE = 'cadence'
+    PEAK_VALUE = 'peak_value'
+    TROUGH_VALUE = 'trough_value'
+    START_HEEL_STRIKE_VALUE = 'start_heel_strike_value'
+    STOP_HEEL_STRIKE_VALUE = 'stop_heel_strike_value'
+    MEAN_VALUE = 'mean_value'
+    MEDIAN_VALUE = 'median_value'
+    STD_VALUE = 'std_value'
+    STANCE_TIME = 'stance_time'
+    SWING_TIME = 'swing_time'
+    TOE_OFF_VALUE = 'toe_off_value'
+    STANCE_MEAN_VALUE = 'stance_mean_value'
+    STANCE_MEDIAN_VALUE = 'stance_median_value'
+    STANCE_STD_VALUE = 'stance_std_value'
+    SWING_MEAN_VALUE = 'swing_mean_value'
+    SWING_MEDIAN_VALUE = 'swing_median_value'
+    SWING_STD_VALUE = 'swing_std_value'
+
+
+# Metrics that require only stride_data (no component or toe_off_time)
+METRIC_FUNCTION_MAP_TIME = {
+    Metric.STRIDE_TIME: compute_stride_time,
+    Metric.CADENCE: compute_cadence,
+}
+
+# Metrics that require stride_data and component
+METRIC_FUNCTION_MAP_COMPONENT = {
+    Metric.PEAK_VALUE: compute_peak_value,
+    Metric.TROUGH_VALUE: compute_trough_value,
+    Metric.START_HEEL_STRIKE_VALUE: compute_start_heel_strike_value,
+    Metric.STOP_HEEL_STRIKE_VALUE: compute_stop_heel_strike_value,
+    Metric.MEAN_VALUE: compute_mean_value,
+    Metric.MEDIAN_VALUE: compute_median_value,
+    Metric.STD_VALUE: compute_std_value,
+}
+
+# Metrics that require stride_data and toe_off_time
+METRIC_FUNCTION_MAP_PHASE_TIME = {
+    Metric.STANCE_TIME: compute_stance_time,
+    Metric.SWING_TIME: compute_swing_time,
+}
+
+# Metrics that require stride_data, toe_off_time, and component
+METRIC_FUNCTION_MAP_PHASE_COMPONENT = {
+    Metric.TOE_OFF_VALUE: compute_toe_off_value,
+    Metric.STANCE_MEAN_VALUE: compute_stance_mean_value,
+    Metric.STANCE_MEDIAN_VALUE: compute_stance_median_value,
+    Metric.STANCE_STD_VALUE: compute_stance_std_value,
+    Metric.SWING_MEAN_VALUE: compute_swing_mean_value,
+    Metric.SWING_MEDIAN_VALUE: compute_swing_median_value,
+    Metric.SWING_STD_VALUE: compute_swing_std_value,
+}
+
+
 @dataclass
 class Metadata:
     position: str
@@ -583,74 +618,25 @@ class GaitMetricsCalculator:
                 **{metric.value: None for metric in metrics},
             }
             for metric in metrics:
-                if metric == Metric.STRIDE_TIME:
-                    stride_metrics[metric.value] = compute_stride_time(stride_data)
-                elif metric == Metric.CADENCE:
-                    stride_metrics[metric.value] = compute_cadence(stride_data)
-                elif metric == Metric.PEAK_VALUE:
-                    stride_metrics[metric.value] = compute_peak_value(
+                if metric in METRIC_FUNCTION_MAP_TIME.keys():
+                    func = METRIC_FUNCTION_MAP_TIME[metric]
+                    stride_metrics[metric.value] = func(stride_data)
+                elif metric in METRIC_FUNCTION_MAP_COMPONENT.keys():
+                    func = METRIC_FUNCTION_MAP_COMPONENT[metric]
+                    stride_metrics[metric.value] = func(
                         stride_data, self.meta.component
                     )
-                elif metric == Metric.TROUGH_VALUE:
-                    stride_metrics[metric.value] = compute_trough_value(
-                        stride_data, self.meta.component
-                    )
-                elif metric == Metric.START_HEEL_STRIKE_VALUE:
-                    stride_metrics[metric.value] = compute_start_heel_strike_value(
-                        stride_data, self.meta.component
-                    )
-                elif metric == Metric.STOP_HEEL_STRIKE_VALUE:
-                    stride_metrics[metric.value] = compute_stop_heel_strike_value(
-                        stride_data, self.meta.component
-                    )
-                elif metric == Metric.MEAN_VALUE:
-                    stride_metrics[metric.value] = compute_mean_value(
-                        stride_data, self.meta.component
-                    )
-                elif metric == Metric.MEDIAN_VALUE:
-                    stride_metrics[metric.value] = compute_median_value(
-                        stride_data, self.meta.component
-                    )
-                elif metric == Metric.STD_VALUE:
-                    stride_metrics[metric.value] = compute_std_value(
-                        stride_data, self.meta.component
-                    )
-                elif metric == Metric.TOE_OFF_VALUE and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_toe_off_value(
+                elif metric in METRIC_FUNCTION_MAP_PHASE_TIME.keys():
+                    func = METRIC_FUNCTION_MAP_PHASE_TIME[metric]
+                    stride_metrics[metric.value] = func(stride_data, toe_off_time)
+                elif metric in METRIC_FUNCTION_MAP_PHASE_COMPONENT.keys():
+                    func = METRIC_FUNCTION_MAP_PHASE_COMPONENT[metric]
+                    stride_metrics[metric.value] = func(
                         stride_data, toe_off_time, self.meta.component
                     )
-                elif metric == Metric.STANCE_TIME and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_stance_time(
-                        stride_data, toe_off_time
-                    )
-                elif metric == Metric.STANCE_MEAN_VALUE and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_stance_mean_value(
-                        stride_data, toe_off_time, self.meta.component
-                    )
-                elif metric == Metric.STANCE_MEDIAN_VALUE and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_stance_median_value(
-                        stride_data, toe_off_time, self.meta.component
-                    )
-                elif metric == Metric.STANCE_STD_VALUE and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_stance_std_value(
-                        stride_data, toe_off_time, self.meta.component
-                    )
-                elif metric == Metric.SWING_TIME and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_swing_time(
-                        stride_data, toe_off_time
-                    )
-                elif metric == Metric.SWING_MEAN_VALUE and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_swing_mean_value(
-                        stride_data, toe_off_time, self.meta.component
-                    )
-                elif metric == Metric.SWING_MEDIAN_VALUE and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_swing_median_value(
-                        stride_data, toe_off_time, self.meta.component
-                    )
-                elif metric == Metric.SWING_STD_VALUE and toe_off_time is not None:
-                    stride_metrics[metric.value] = compute_swing_std_value(
-                        stride_data, toe_off_time, self.meta.component
-                    )
+                else:
+                    print(f"Metric {metric} not recognized. Skipping.")
+
             all_strides_metrics_list.append(stride_metrics)
 
         all_strides_metrics = pd.DataFrame(all_strides_metrics_list)

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -68,13 +68,13 @@ class Metric(Enum):
     SWING_STD_VALUE = 'swing_std_value'
 
 
-def compute_stride_time(stride_data):
+def compute_stride_time(stride_data: np.ndarray) -> float:
     if stride_data.shape[0] == 0:
         return None
     return stride_data['elapsed_s'].max() - stride_data['elapsed_s'].min()
 
 
-def compute_cadence(stride_data):
+def compute_cadence(stride_data: np.ndarray) -> float:
     if stride_data.shape[0] == 0:
         return None
     duration = compute_stride_time(stride_data)
@@ -83,62 +83,72 @@ def compute_cadence(stride_data):
     return 60 / duration
 
 
-def compute_peak_value(stride_data, component='x'):
+def compute_peak_value(stride_data: np.ndarray, component: str = 'x') -> float:
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].max()
 
 
-def compute_trough_value(stride_data, component='x'):
+def compute_trough_value(stride_data: np.ndarray, component: str = 'x') -> float:
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].min()
 
 
-def compute_start_heel_strike_value(stride_data, component='x'):
+def compute_start_heel_strike_value(
+    stride_data: np.ndarray, component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0:
         return None
     return stride_data[0][component]
 
 
-def compute_stop_heel_strike_value(stride_data, component='x'):
+def compute_stop_heel_strike_value(
+    stride_data: np.ndarray, component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0:
         return None
     return stride_data[-1][component]
 
 
-def compute_mean_value(stride_data, component='x'):
+def compute_mean_value(stride_data: np.ndarray, component: str = 'x') -> float:
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].mean()
 
 
-def compute_median_value(stride_data, component='x'):
+def compute_median_value(stride_data: np.ndarray, component: str = 'x') -> float:
     if stride_data.shape[0] == 0:
         return None
     return np.median(stride_data[component])
 
 
-def compute_std_value(stride_data, component='x'):
+def compute_std_value(stride_data: np.ndarray, component: str = 'x') -> float:
     if stride_data.shape[0] == 0:
         return None
     return stride_data[component].std()
 
 
-def compute_toe_off_value(stride_data, toe_off_time, component='x'):
+def compute_toe_off_value(
+    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     closest_index = np.abs(stride_data['elapsed_s'] - toe_off_time).argmin()
     return stride_data[closest_index][component]
 
 
-def compute_stance_time(stride_data, toe_off_time):
+def compute_stance_time(
+    stride_data: np.ndarray, toe_off_time: Optional[float]
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     return toe_off_time - stride_data['elapsed_s'].min()
 
 
-def compute_stance_mean_value(stride_data, toe_off_time, component='x'):
+def compute_stance_mean_value(
+    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
@@ -147,7 +157,9 @@ def compute_stance_mean_value(stride_data, toe_off_time, component='x'):
     return compute_mean_value(stance_data, component)
 
 
-def compute_stance_median_value(stride_data, toe_off_time, component='x'):
+def compute_stance_median_value(
+    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
@@ -156,7 +168,9 @@ def compute_stance_median_value(stride_data, toe_off_time, component='x'):
     return compute_median_value(stance_data, component)
 
 
-def compute_stance_std_value(stride_data, toe_off_time, component='x'):
+def compute_stance_std_value(
+    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
@@ -165,13 +179,15 @@ def compute_stance_std_value(stride_data, toe_off_time, component='x'):
     return compute_std_value(stance_data, component)
 
 
-def compute_swing_time(stride_data, toe_off_time):
+def compute_swing_time(stride_data: np.ndarray, toe_off_time: Optional[float]) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     return stride_data['elapsed_s'].max() - toe_off_time
 
 
-def compute_swing_mean_value(stride_data, toe_off_time, component='x'):
+def compute_swing_mean_value(
+    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
@@ -180,7 +196,9 @@ def compute_swing_mean_value(stride_data, toe_off_time, component='x'):
     return compute_mean_value(swing_data, component)
 
 
-def compute_swing_median_value(stride_data, toe_off_time, component='x'):
+def compute_swing_median_value(
+    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
@@ -189,7 +207,9 @@ def compute_swing_median_value(stride_data, toe_off_time, component='x'):
     return compute_median_value(swing_data, component)
 
 
-def compute_swing_std_value(stride_data, toe_off_time, component='x'):
+def compute_swing_std_value(
+    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+) -> float:
     if stride_data.shape[0] == 0 or toe_off_time is None:
         return None
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
@@ -211,12 +231,12 @@ class Metadata:
 class GaitMetricsCalculator:
     def __init__(
         self,
-        stream,
-        stride_splits,
-        meta,
-        toe_off_times=None,
-        shank_stream=None,
-    ):
+        stream: np.ndarray,
+        stride_splits: np.ndarray,
+        meta: Metadata,
+        toe_off_times: Optional[np.ndarray] = None,
+        shank_stream: Optional[np.ndarray] = None,
+    ) -> None:
         self.stream = stream
         self.stride_splits = stride_splits
         self.meta = meta
@@ -227,14 +247,14 @@ class GaitMetricsCalculator:
         else:
             self.toe_off_times = None
 
-    def compute_toe_offs(self, shank_stream):
+    def compute_toe_offs(self, shank_stream: np.ndarray) -> np.ndarray:
         grouped_toe_off_times = kinematics.get_grouped_walking_splits(
             shank_stream, factor=-1.0
         )
         toe_off_times = [item for sublist in grouped_toe_off_times for item in sublist]
         return np.array(toe_off_times)
 
-    def get_toe_off_time(self, stride_data):
+    def get_toe_off_time(self, stride_data: np.ndarray) -> Optional[float]:
         if self.toe_off_times is None:
             return None
         # Find the toe off time falling in the time range of the stride
@@ -247,7 +267,11 @@ class GaitMetricsCalculator:
                 return toe_off_time
         return None
 
-    def calculate_metrics(self, metrics=None, output_path=None):
+    def calculate_metrics(
+        self,
+        metrics: Optional[list[Metric]] = None,
+        output_path: Optional[str] = None,
+    ) -> pd.DataFrame:
         if metrics is None:
             metrics = list(Metric)
 
@@ -368,19 +392,19 @@ class GaitMetricsCalculator:
 
 
 def compute_gait_metrics(
-    stream,
-    stride_splits,
-    position,
-    stream_name,
-    component,
-    orgid=None,
-    study=None,
-    collection_num=None,
-    toe_off_times=None,
-    shank_stream=None,
-    metrics=None,
-    output_path=None,
-):
+    stream: np.ndarray,
+    stride_splits: np.ndarray,
+    position: int,
+    stream_name: str,
+    component: str,
+    orgid: Optional[str] = None,
+    study: Optional[str] = None,
+    collection_num: Optional[int] = None,
+    toe_off_times: Optional[np.ndarray] = None,
+    shank_stream: Optional[np.ndarray] = None,
+    metrics: Optional[list[Metric]] = None,
+    output_path: Optional[str] = None,
+) -> pd.DataFrame:
     metrics_calculator = GaitMetricsCalculator(
         stream=stream,
         stride_splits=stride_splits,

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -1,39 +1,61 @@
 """
-Arguments:
-    stream: Kinematics input data for which gait metrics need to be calculated.
-    stride_splits: Array of stride splits, each containing start and stop times.
-    toe_off_times: [Optional] Array of toe off timestamps with shape (n_toe_offs,).
-        Compute inside class if not provided.
-    component: Component of the stream to analyze, e.g. 'x', 'knee_flexion'.
-    segment: Metadata segment to use for analysis.
+This module provides tools for calculating gait metrics from kinematic data streams.
+
+It processes stride-based movement data, computes a variety of temporal and spatial
+metrics for each stride, and outputs results in a structured CSV format. The module
+supports flexible metric selection, stride segmentation, and optional toe-off event
+detection. It is designed for use in gait analysis studies, biomechanics research,
+and clinical movement assessments.
+
+Typical usage involves providing a kinematic data stream, stride boundaries, and
+optional metadata. The module extracts stride segments, computes metrics such as
+stride time, cadence, peak/trough values, and stance/swing phase statistics, and
+saves the results to disk for further analysis.
+
+Usage Example:
+
+    metrics_calculator = gait_metrics.GaitMetricsCalculator(
+        stream=kinematic_data_stream,
+        stride_splits=stride_splits,
+        shank_stream=kinematic_shank_stream,
+        meta=gait_metrics.Metadata(
+            orgid=orgid,
+            study=study,
+            collection_num=collection_num,
+            position='r_shank',
+            stream_name='euler',
+            component='x',
+        ),
+    )
+    metrics_df = metrics_calculator.calculate_metrics(output_path="recordings")
 
 Output:
-    CSV file containing gait metrics for each stride. Each row is a stride with
-    columns for start time, stop time, elapsed time, and the calculated metrics.
+    CSV file containing gait metrics for each stride. Each row represents a stride
+    with columns for start time, stop time, elapsed time, and computed metrics.
 
 Filename structure:
     {output_path}/{study}_{collection_num}_{position}_
     {stream}_{component}_gait_metrics.csv
 
-Metrics:
+Available metrics include:
     - stride_time: Duration of the stride.
     - cadence: Steps per minute.
-    - peak_value: Peak value of the specified component during the stride.
-    - trough_value: Trough value of the specified component during the stride.
-    - start_heel_strike_value: Value of the component at the start of the stride.
-    - stop_heel_strike_value: Value of the component at the end of the stride.
-    - mean_value: Mean value of the component during the stride.
-    - median_value: Median value of the component during the stride.
-    - std_value: Standard deviation of the component during the stride.
-    - toe_off_value: Value of the component at the toe off time.
+    - peak_value: Maximum value of the component during the stride.
+    - trough_value: Minimum value of the component during the stride.
+    - start_heel_strike_value: Value at the start of the stride.
+    - stop_heel_strike_value: Value at the end of the stride.
+    - mean_value: Mean value during the stride.
+    - median_value: Median value during the stride.
+    - std_value: Standard deviation during the stride.
+    - toe_off_value: Value at the toe-off event.
     - stance_time: Duration of the stance phase.
-    - stance_mean_value: Mean value of the component during the stance phase.
-    - stance_median_value: Median value of the component during the stance phase.
-    - stance_std_value: Standard deviation of the component during the stance phase.
+    - stance_mean_value: Mean value during stance phase.
+    - stance_median_value: Median value during stance phase.
+    - stance_std_value: Standard deviation during stance phase.
     - swing_time: Duration of the swing phase.
-    - swing_mean_value: Mean value of the component during the swing phase.
-    - swing_median_value: Median value of the component during the swing phase.
-    - swing_std_value: Standard deviation of the component during the swing phase.
+    - swing_mean_value: Mean value during swing phase.
+    - swing_median_value: Median value during swing phase.
+    - swing_std_value: Standard deviation during swing phase.
 """
 
 import os

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -77,7 +77,7 @@ def compute_stride_time(stride_data: np.ndarray) -> float:
     Compute the stride time for the given stride data.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
 
     Returns:
         float: Duration of the stride, or None if data is empty.
@@ -92,7 +92,7 @@ def compute_cadence(stride_data: np.ndarray) -> float:
     Compute cadence (steps per minute) for the stride data.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
 
     Returns:
         float: Cadence value, or None if data is empty or duration is zero.
@@ -110,7 +110,7 @@ def compute_peak_value(stride_data: np.ndarray, component: str = 'x') -> float:
     Compute the peak value of a component during the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         component (str): Component name to analyze.
 
     Returns:
@@ -126,7 +126,7 @@ def compute_trough_value(stride_data: np.ndarray, component: str = 'x') -> float
     Compute the trough value of a component during the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         component (str): Component name to analyze.
 
     Returns:
@@ -144,7 +144,7 @@ def compute_start_heel_strike_value(
     Get the value of a component at the start of the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         component (str): Component name to analyze.
 
     Returns:
@@ -162,7 +162,7 @@ def compute_stop_heel_strike_value(
     Get the value of a component at the end of the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         component (str): Component name to analyze.
 
     Returns:
@@ -178,7 +178,7 @@ def compute_mean_value(stride_data: np.ndarray, component: str = 'x') -> float:
     Compute the mean value of a component during the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         component (str): Component name to analyze.
 
     Returns:
@@ -194,7 +194,7 @@ def compute_median_value(stride_data: np.ndarray, component: str = 'x') -> float
     Compute the median value of a component during the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         component (str): Component name to analyze.
 
     Returns:
@@ -210,7 +210,7 @@ def compute_std_value(stride_data: np.ndarray, component: str = 'x') -> float:
     Compute the standard deviation of a component during the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         component (str): Component name to analyze.
 
     Returns:
@@ -228,7 +228,7 @@ def compute_toe_off_value(
     Get the value of a component at the toe off time.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
         component (str): Component name to analyze.
 
@@ -248,7 +248,7 @@ def compute_stance_time(
     Compute the duration of the stance phase for the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
 
     Returns:
@@ -266,7 +266,7 @@ def compute_stance_mean_value(
     Compute mean value of a component during the stance phase.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
         component (str): Component name to analyze.
 
@@ -288,7 +288,7 @@ def compute_stance_median_value(
     Compute median value of a component during the stance phase.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
         component (str): Component name to analyze.
 
@@ -310,7 +310,7 @@ def compute_stance_std_value(
     Compute standard deviation of a component during the stance phase.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
         component (str): Component name to analyze.
 
@@ -330,7 +330,7 @@ def compute_swing_time(stride_data: np.ndarray, toe_off_time: Optional[float]) -
     Compute the duration of the swing phase for the stride.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
 
     Returns:
@@ -348,7 +348,7 @@ def compute_swing_mean_value(
     Compute mean value of a component during the swing phase.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
         component (str): Component name to analyze.
 
@@ -370,7 +370,7 @@ def compute_swing_median_value(
     Compute median value of a component during the swing phase.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
         component (str): Component name to analyze.
 
@@ -392,7 +392,7 @@ def compute_swing_std_value(
     Compute standard deviation of a component during the swing phase.
 
     Args:
-        stride_data (np.ndarray): Array of stride data.
+        stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
         toe_off_time (float): Toe off timestamp.
         component (str): Component name to analyze.
 
@@ -489,11 +489,14 @@ class GaitMetricsCalculator:
         if available.
 
         Args:
-            stream (np.ndarray): Kinematics input data.
-            stride_splits (np.ndarray): Array of stride splits.
+            stream (np.ndarray): Kinematics input data. Numpy record array with fields
+                including 'elapsed_s' and the component to analyze.
+            stride_splits (np.ndarray): Array of stride splits. Numpy record array with
+                fields 'start_s' and 'stop_s'.
             meta (Metadata): Metadata for analysis.
             toe_off_times (np.ndarray, optional): Toe off timestamps.
-            shank_stream (np.ndarray, optional): Shank stream data.
+            shank_stream (np.ndarray, optional): Shank stream data. Numpy record array
+                with 'elapsed_s' field, used to compute toe_off_times if not provided.
         """
         self.stream = stream
         self.stride_splits = stride_splits
@@ -510,7 +513,8 @@ class GaitMetricsCalculator:
         Compute toe off times from shank stream data.
 
         Args:
-            shank_stream (np.ndarray): Shank stream data.
+            shank_stream (np.ndarray): Shank stream data, NumPy record with 'elapsed_s'
+                field.
 
         Returns:
             np.ndarray: Array of toe off timestamps.
@@ -526,7 +530,7 @@ class GaitMetricsCalculator:
         Get the toe off time within the stride data range.
 
         Args:
-            stride_data (np.ndarray): Array of stride data.
+            stride_data (np.ndarray): Stride data, NumPy record with 'elapsed_s' field.
 
         Returns:
             float: Toe off timestamp, or None if not found.
@@ -664,8 +668,10 @@ def compute_gait_metrics(
     Compute gait metrics for all strides and save to CSV if output_path is given.
 
     Args:
-        stream (np.ndarray): Kinematics input data.
-        stride_splits (np.ndarray): Array of stride splits.
+        stream (np.ndarray): Kinematics input data, NumPy record array with fields
+            including 'elapsed_s' and the component to analyze.
+        stride_splits (np.ndarray): Array of stride splits, NumPy record array with
+            fields 'start_s' and 'stop_s'.
         position (str): Position identifier, e.g. 'r_shank'
         stream_name (str): Name of the stream.
         component (str): Component to analyze, e.g. 'x', 'knee_flexion'.

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -22,8 +22,8 @@ Usage Example (Code):
         stride_splits=stride_splits,
         shank_stream=kinematic_shank_stream,
         meta=gait_metrics.Metadata(
-            orgid=orgid,
-            study=study,
+            org_shortname=org_shortname,
+            study_shortname=study_shortname,
             collection_num=collection_num,
             position='r_shank',
             stream_name='euler',
@@ -37,7 +37,7 @@ Output:
     with columns for start time, stop time, elapsed time, and computed metrics.
 
 Filename structure:
-    {output_path}/{study}_{collection_num}_{position}_
+    {output_path}/{study_shortname}_{collection_num}_{position}_
     {stream}_{component}_gait_metrics.csv
 
 Available metrics include:
@@ -433,8 +433,8 @@ class Metadata:
     position: str
     stream_name: str
     component: str
-    orgid: Optional[str] = None
-    study: Optional[str] = None
+    org_shortname: Optional[str] = None
+    study_shortname: Optional[str] = None
     collection_num: Optional[int] = None
 
 
@@ -515,16 +515,20 @@ class GaitMetricsCalculator:
             all_strides_metrics (pd.DataFrame): DataFrame containing the metrics.
             output_path (str): Path to the output CSV file.
         """
-        if self.meta.orgid and self.meta.study and self.meta.collection_num:
+        if (
+            self.meta.org_shortname
+            and self.meta.study_shortname
+            and self.meta.collection_num
+        ):
             output_path = os.path.join(
                 output_path,
-                self.meta.orgid,
-                self.meta.study,
+                self.meta.org_shortname,
+                self.meta.study_shortname,
                 str(self.meta.collection_num),
             )
             file_path = (
-                f"{output_path}/{self.meta.orgid}_"
-                f"{self.meta.study}_{self.meta.collection_num}_"
+                f"{output_path}/{self.meta.org_shortname}_"
+                f"{self.meta.study_shortname}_{self.meta.collection_num}_"
                 f"{self.meta.position}_{self.meta.stream_name}_"
                 f"{self.meta.component}_gait_metrics.csv"
             )
@@ -652,8 +656,8 @@ def compute_gait_metrics(
     position: str,
     stream_name: str,
     component: str,
-    orgid: Optional[str] = None,
-    study: Optional[str] = None,
+    org_shortname: Optional[str] = None,
+    study_shortname: Optional[str] = None,
     collection_num: Optional[int] = None,
     toe_off_times: Optional[np.ndarray] = None,
     shank_stream: Optional[np.ndarray] = None,
@@ -669,8 +673,8 @@ def compute_gait_metrics(
         position (str): Position identifier, e.g. 'r_shank'
         stream_name (str): Name of the stream.
         component (str): Component to analyze, e.g. 'x', 'knee_flexion'.
-        orgid (str, optional): Organization ID.
-        study (str, optional): Study name.
+        org_shortname (str, optional): Organization ID.
+        study_shortname (str, optional): Study name.
         collection_num (int, optional): Collection number.
         toe_off_times (np.ndarray, optional): Toe off timestamps.
         shank_stream (np.ndarray, optional): Shank stream data.
@@ -687,8 +691,8 @@ def compute_gait_metrics(
             position=position,
             stream_name=stream_name,
             component=component,
-            orgid=orgid,
-            study=study,
+            org_shortname=org_shortname,
+            study_shortname=study_shortname,
             collection_num=collection_num,
         ),
         toe_off_times=toe_off_times,

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -1,0 +1,333 @@
+"""
+Arguments:
+    stream: Kinematics input data for which gait metrics need to be calculated.
+    stride_splits: Array of stride splits, each containing start and stop times.
+    toe_off_times: [Optional] Array of toe off timestamps with shape (n_toe_offs,).
+        Compute inside class if not provided.
+    component: Component of the stream to analyze, e.g. 'x', 'knee_flexion'.
+    segment: Metadata segment to use for analysis.
+
+Output:
+    CSV file containing gait metrics for each stride. Each row is a stride with
+    columns for start time, stop time, elapsed time, and the calculated metrics.
+
+Filename:
+    {study}_{collection_num}_{position}_{stream}_{component}_gait_metrics.csv
+
+Metrics:
+    - stride_time: Duration of the stride.
+    - cadence: Steps per minute.
+    - peak_value: Peak value of the specified component during the stride.
+    - trough_value: Trough value of the specified component during the stride.
+    - start_heel_strike_value: Value of the component at the start of the stride.
+    - stop_heel_strike_value: Value of the component at the end of the stride.
+    - mean_value: Mean value of the component during the stride.
+    - median_value: Median value of the component during the stride.
+    - std_value: Standard deviation of the component during the stride.
+    - toe_off_value: Value of the component at the toe off time.
+    - stance_time: Duration of the stance phase.
+    - stance_mean_value: Mean value of the component during the stance phase.
+    - stance_median_value: Median value of the component during the stance phase.
+    - stance_std_value: Standard deviation of the component during the stance phase.
+    - swing_time: Duration of the swing phase.
+    - swing_mean_value: Mean value of the component during the swing phase.
+    - swing_median_value: Median value of the component during the swing phase.
+    - swing_std_value: Standard deviation of the component during the swing phase.
+"""
+
+from enum import Enum
+
+import numpy as np
+import pandas as pd
+
+from cionic import kinematics
+
+
+class Metric(Enum):
+    STRIDE_TIME = 'stride_time'
+    CADENCE = 'cadence'
+    PEAK_VALUE = 'peak_value'
+    TROUGH_VALUE = 'trough_value'
+    START_HEEL_STRIKE_VALUE = 'start_heel_strike_value'
+    STOP_HEEL_STRIKE_VALUE = 'stop_heel_strike_value'
+    MEAN_VALUE = 'mean_value'
+    MEDIAN_VALUE = 'median_value'
+    STD_VALUE = 'std_value'
+    TOE_OFF_VALUE = 'toe_off_value'
+    STANCE_TIME = 'stance_time'
+    STANCE_MEAN_VALUE = 'stance_mean_value'
+    STANCE_MEDIAN_VALUE = 'stance_median_value'
+    STANCE_STD_VALUE = 'stance_std_value'
+    SWING_TIME = 'swing_time'
+    SWING_MEAN_VALUE = 'swing_mean_value'
+    SWING_MEDIAN_VALUE = 'swing_median_value'
+    SWING_STD_VALUE = 'swing_std_value'
+
+
+def compute_stride_time(stride_data):
+    if stride_data.shape[0] == 0:
+        return None
+    return stride_data['elapsed_s'].max() - stride_data['elapsed_s'].min()
+
+
+def compute_cadence(stride_data):
+    if stride_data.shape[0] == 0:
+        return None
+    duration = compute_stride_time(stride_data)
+    if duration is None or duration == 0:
+        return None
+    return 60 / duration
+
+
+def compute_peak_value(stride_data, component='x'):
+    if stride_data.shape[0] == 0:
+        return None
+    return stride_data[component].max()
+
+
+def compute_trough_value(stride_data, component='x'):
+    if stride_data.shape[0] == 0:
+        return None
+    return stride_data[component].min()
+
+
+def compute_start_heel_strike_value(stride_data, component='x'):
+    if stride_data.shape[0] == 0:
+        return None
+    return stride_data[0][component]
+
+
+def compute_stop_heel_strike_value(stride_data, component='x'):
+    if stride_data.shape[0] == 0:
+        return None
+    return stride_data[-1][component]
+
+
+def compute_mean_value(stride_data, component='x'):
+    if stride_data.shape[0] == 0:
+        return None
+    return stride_data[component].mean()
+
+
+def compute_median_value(stride_data, component='x'):
+    if stride_data.shape[0] == 0:
+        return None
+    return np.median(stride_data[component])
+
+
+def compute_std_value(stride_data, component='x'):
+    if stride_data.shape[0] == 0:
+        return None
+    return stride_data[component].std()
+
+
+def compute_toe_off_value(stride_data, toe_off_time, component='x'):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    closest_index = np.abs(stride_data['elapsed_s'] - toe_off_time).argmin()
+    return stride_data[closest_index][component]
+
+
+def compute_stance_time(stride_data, toe_off_time):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    return toe_off_time - stride_data['elapsed_s'].min()
+
+
+def compute_stance_mean_value(stride_data, toe_off_time, component='x'):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
+    if stance_data.shape[0] == 0:
+        return None
+    return stance_data[component].mean()
+
+
+def compute_stance_median_value(stride_data, toe_off_time, component='x'):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
+    if stance_data.shape[0] == 0:
+        return None
+    return np.median(stance_data[component])
+
+
+def compute_stance_std_value(stride_data, toe_off_time, component='x'):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
+    if stance_data.shape[0] == 0:
+        return None
+    return stance_data[component].std()
+
+
+def compute_swing_time(stride_data, toe_off_time):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    return stride_data['elapsed_s'].max() - toe_off_time
+
+
+def compute_swing_mean_value(stride_data, toe_off_time, component='x'):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
+    if swing_data.shape[0] == 0:
+        return None
+    return swing_data[component].mean()
+
+
+def compute_swing_median_value(stride_data, toe_off_time, component='x'):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
+    if swing_data.shape[0] == 0:
+        return None
+    return np.median(swing_data[component])
+
+
+def compute_swing_std_value(stride_data, toe_off_time, component='x'):
+    if stride_data.shape[0] == 0 or toe_off_time is None:
+        return None
+    swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
+    if swing_data.shape[0] == 0:
+        return None
+    return swing_data[component].std()
+
+
+class GaitMetricsCalculator:
+    def __init__(
+        self,
+        stream,
+        stride_splits,
+        segment,
+        component='x',
+        toe_off_times=None,
+        shank_stream=None,
+    ):
+        self.stream = stream
+        self.stride_splits = stride_splits
+        self.segment = segment
+        self.component = component
+        if toe_off_times is not None:
+            self.toe_off_times = toe_off_times
+        elif shank_stream is not None:
+            self.toe_off_times = self.compute_toe_offs(shank_stream)
+        else:
+            self.toe_off_times = None
+
+    def compute_toe_offs(self, shank_stream):
+        grouped_toe_off_times = kinematics.get_grouped_walking_splits(
+            shank_stream, factor=-1.0
+        )
+        toe_off_times = [item for sublist in grouped_toe_off_times for item in sublist]
+        return np.array(toe_off_times)
+
+    def get_toe_off_time(self, stride_data):
+        if self.toe_off_times is None:
+            return None
+        # Find the toe off time falling in the time range of the stride
+        for toe_off_time in self.toe_off_times:
+            if (
+                stride_data['elapsed_s'].min()
+                <= toe_off_time
+                <= stride_data['elapsed_s'].max()
+            ):
+                return toe_off_time
+        return None
+
+    def calculate_metrics(self, metrics=None, output_path=None):
+
+        all_strides_metrics_list = []
+        for stride in self.stride_splits:
+            # Extract relevant data for the current stride
+            start_s = stride['start_s']
+            stop_s = stride['stop_s']
+
+            stride_data = self.stream[
+                (self.stream['elapsed_s'] >= start_s)
+                & (self.stream['elapsed_s'] <= stop_s)
+            ]
+
+            if metrics is None:
+                metrics = list(Metric)
+
+            stride_metrics = {
+                metric.value: None for metric in metrics
+            }  # TODO: decide on this or initialize with {}
+
+            toe_off_time = self.get_toe_off_time(stride_data)
+            for metric in metrics:
+                if metric == Metric.STRIDE_TIME:
+                    stride_metrics[metric.value] = compute_stride_time(stride_data)
+                elif metric == Metric.CADENCE:
+                    stride_metrics[metric.value] = compute_cadence(stride_data)
+                elif metric == Metric.PEAK_VALUE:
+                    stride_metrics[metric.value] = compute_peak_value(
+                        stride_data, self.component
+                    )
+                elif metric == Metric.TROUGH_VALUE:
+                    stride_metrics[metric.value] = compute_trough_value(
+                        stride_data, self.component
+                    )
+                elif metric == Metric.START_HEEL_STRIKE_VALUE:
+                    stride_metrics[metric.value] = compute_start_heel_strike_value(
+                        stride_data, self.component
+                    )
+                elif metric == Metric.STOP_HEEL_STRIKE_VALUE:
+                    stride_metrics[metric.value] = compute_stop_heel_strike_value(
+                        stride_data, self.component
+                    )
+                elif metric == Metric.MEAN_VALUE:
+                    stride_metrics[metric.value] = compute_mean_value(
+                        stride_data, self.component
+                    )
+                elif metric == Metric.MEDIAN_VALUE:
+                    stride_metrics[metric.value] = compute_median_value(
+                        stride_data, self.component
+                    )
+                elif metric == Metric.STD_VALUE:
+                    stride_metrics[metric.value] = compute_std_value(
+                        stride_data, self.component
+                    )
+                elif metric == Metric.TOE_OFF_VALUE and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_toe_off_value(
+                        stride_data, toe_off_time, self.component
+                    )
+                elif metric == Metric.STANCE_TIME and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_stance_time(
+                        stride_data, toe_off_time
+                    )
+                elif metric == Metric.STANCE_MEAN_VALUE and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_stance_mean_value(
+                        stride_data, toe_off_time, self.component
+                    )
+                elif metric == Metric.STANCE_MEDIAN_VALUE and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_stance_median_value(
+                        stride_data, toe_off_time, self.component
+                    )
+                elif metric == Metric.STANCE_STD_VALUE and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_stance_std_value(
+                        stride_data, toe_off_time, self.component
+                    )
+                elif metric == Metric.SWING_TIME and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_swing_time(
+                        stride_data, toe_off_time
+                    )
+                elif metric == Metric.SWING_MEAN_VALUE and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_swing_mean_value(
+                        stride_data, toe_off_time, self.component
+                    )
+                elif metric == Metric.SWING_MEDIAN_VALUE and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_swing_median_value(
+                        stride_data, toe_off_time, self.component
+                    )
+                elif metric == Metric.SWING_STD_VALUE and toe_off_time is not None:
+                    stride_metrics[metric.value] = compute_swing_std_value(
+                        stride_data, toe_off_time, self.component
+                    )
+
+            all_strides_metrics_list.append(stride_metrics)
+        all_strides_metrics = pd.DataFrame(all_strides_metrics_list)
+        if output_path is not None:
+            all_strides_metrics.to_csv(output_path, index=False)
+        return all_strides_metrics

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -32,6 +32,15 @@ Usage Example (Code):
     )
     metrics_df = metrics_calculator.calculate_metrics(output_path="recordings")
 
+Note on stream data types:
+    The input streams (stream, stride_splits, shank_stream) are expected to be NumPy
+    record arrays with specific fields. For example, the stream should have an
+    'elapsed_s' field and fields for the components being analyzed (e.g., 'x', 'y',
+    'z', 'knee_flexion', etc.). The stride_splits should have 'start_s' and 'stop_s'
+    fields indicating the time boundaries of each stride. Record arrays share many of
+    the same properties as Pandas DataFrames, but are more memory efficient for large
+    datasets.
+
 Output:
     CSV file containing gait metrics for each stride. Each row represents a stride
     with columns for start time, stop time, elapsed time, and computed metrics.

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -486,7 +486,7 @@ class GaitMetricsCalculator:
         toe_off_times = [item for sublist in grouped_toe_off_times for item in sublist]
         return np.array(toe_off_times)
 
-    def _get_toe_off_time(self, stride_data: np.ndarray) -> Optional[float]:
+    def _get_toe_off_time_in_stride(self, stride_data: np.ndarray) -> Optional[float]:
         """
         Get the toe off time within the stride data range.
 
@@ -498,15 +498,22 @@ class GaitMetricsCalculator:
         """
         if self.toe_off_times is None:
             return None
-        # Find the toe off time falling in the time range of the stride
-        for toe_off_time in self.toe_off_times:
-            if (
-                stride_data['elapsed_s'].min()
-                <= toe_off_time
-                <= stride_data['elapsed_s'].max()
-            ):
-                return toe_off_time
-        return None
+        start = stride_data['elapsed_s'].min()
+        stop = stride_data['elapsed_s'].max()
+
+        # Vectorized selection of toe_off_times within stride range
+        valid_toe_offs = self.toe_off_times[
+            (self.toe_off_times >= start) & (self.toe_off_times <= stop)
+        ]
+        if valid_toe_offs.shape[0] == 0:
+            print(f"No toe_off_time found in stride range ({start}, {stop}).")
+            return None
+        if valid_toe_offs.shape[0] > 1:
+            print(
+                f"Multiple toe_off_times ({valid_toe_offs}) found in stride range "
+                f"({start}, {stop}). Using the first."
+            )
+        return valid_toe_offs[0]
 
     def _output_metrics_to_csv(
         self, all_strides_metrics: pd.DataFrame, output_path: str
@@ -569,7 +576,7 @@ class GaitMetricsCalculator:
                 (self.stream['elapsed_s'] >= stride['start_s'])
                 & (self.stream['elapsed_s'] <= stride['stop_s'])
             ]
-            toe_off_time = self._get_toe_off_time(stride_data)
+            toe_off_time = self._get_toe_off_time_in_stride(stride_data)
 
             stride_metrics = {
                 **{'start_s': stride['start_s'], 'stop_s': stride['stop_s']},

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -11,8 +11,9 @@ Output:
     CSV file containing gait metrics for each stride. Each row is a stride with
     columns for start time, stop time, elapsed time, and the calculated metrics.
 
-Filename:
-    {study}_{collection_num}_{position}_{stream}_{component}_gait_metrics.csv
+Filename structure:
+    {output_path}/{study}_{collection_num}_{position}_
+    {stream}_{component}_gait_metrics.csv
 
 Metrics:
     - stride_time: Duration of the stride.
@@ -35,6 +36,8 @@ Metrics:
     - swing_std_value: Standard deviation of the component during the swing phase.
 """
 
+import os
+from dataclasses import dataclass
 from enum import Enum
 
 import numpy as np
@@ -140,7 +143,7 @@ def compute_stance_mean_value(stride_data, toe_off_time, component='x'):
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
     if stance_data.shape[0] == 0:
         return None
-    return stance_data[component].mean()
+    return compute_mean_value(stance_data, component)
 
 
 def compute_stance_median_value(stride_data, toe_off_time, component='x'):
@@ -149,7 +152,7 @@ def compute_stance_median_value(stride_data, toe_off_time, component='x'):
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
     if stance_data.shape[0] == 0:
         return None
-    return np.median(stance_data[component])
+    return compute_median_value(stance_data, component)
 
 
 def compute_stance_std_value(stride_data, toe_off_time, component='x'):
@@ -158,7 +161,7 @@ def compute_stance_std_value(stride_data, toe_off_time, component='x'):
     stance_data = stride_data[stride_data['elapsed_s'] <= toe_off_time]
     if stance_data.shape[0] == 0:
         return None
-    return stance_data[component].std()
+    return compute_std_value(stance_data, component)
 
 
 def compute_swing_time(stride_data, toe_off_time):
@@ -173,7 +176,7 @@ def compute_swing_mean_value(stride_data, toe_off_time, component='x'):
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
     if swing_data.shape[0] == 0:
         return None
-    return swing_data[component].mean()
+    return compute_mean_value(swing_data, component)
 
 
 def compute_swing_median_value(stride_data, toe_off_time, component='x'):
@@ -182,7 +185,7 @@ def compute_swing_median_value(stride_data, toe_off_time, component='x'):
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
     if swing_data.shape[0] == 0:
         return None
-    return np.median(swing_data[component])
+    return compute_median_value(swing_data, component)
 
 
 def compute_swing_std_value(stride_data, toe_off_time, component='x'):
@@ -191,7 +194,17 @@ def compute_swing_std_value(stride_data, toe_off_time, component='x'):
     swing_data = stride_data[stride_data['elapsed_s'] > toe_off_time]
     if swing_data.shape[0] == 0:
         return None
-    return swing_data[component].std()
+    return compute_std_value(swing_data, component)
+
+
+@dataclass
+class Metadata:
+    orgid: str
+    study: str
+    collection_num: int
+    position: int
+    stream_name: str
+    component: str
 
 
 class GaitMetricsCalculator:
@@ -199,15 +212,13 @@ class GaitMetricsCalculator:
         self,
         stream,
         stride_splits,
-        segment,
-        component='x',
+        meta,
         toe_off_times=None,
         shank_stream=None,
     ):
         self.stream = stream
         self.stride_splits = stride_splits
-        self.segment = segment
-        self.component = component
+        self.meta = meta
         if toe_off_times is not None:
             self.toe_off_times = toe_off_times
         elif shank_stream is not None:
@@ -236,6 +247,8 @@ class GaitMetricsCalculator:
         return None
 
     def calculate_metrics(self, metrics=None, output_path=None):
+        if metrics is None:
+            metrics = list(Metric)
 
         all_strides_metrics_list = []
         for stride in self.stride_splits:
@@ -247,9 +260,6 @@ class GaitMetricsCalculator:
                 (self.stream['elapsed_s'] >= start_s)
                 & (self.stream['elapsed_s'] <= stop_s)
             ]
-
-            if metrics is None:
-                metrics = list(Metric)
 
             stride_metrics = {
                 metric.value: None for metric in metrics
@@ -263,35 +273,35 @@ class GaitMetricsCalculator:
                     stride_metrics[metric.value] = compute_cadence(stride_data)
                 elif metric == Metric.PEAK_VALUE:
                     stride_metrics[metric.value] = compute_peak_value(
-                        stride_data, self.component
+                        stride_data, self.meta.component
                     )
                 elif metric == Metric.TROUGH_VALUE:
                     stride_metrics[metric.value] = compute_trough_value(
-                        stride_data, self.component
+                        stride_data, self.meta.component
                     )
                 elif metric == Metric.START_HEEL_STRIKE_VALUE:
                     stride_metrics[metric.value] = compute_start_heel_strike_value(
-                        stride_data, self.component
+                        stride_data, self.meta.component
                     )
                 elif metric == Metric.STOP_HEEL_STRIKE_VALUE:
                     stride_metrics[metric.value] = compute_stop_heel_strike_value(
-                        stride_data, self.component
+                        stride_data, self.meta.component
                     )
                 elif metric == Metric.MEAN_VALUE:
                     stride_metrics[metric.value] = compute_mean_value(
-                        stride_data, self.component
+                        stride_data, self.meta.component
                     )
                 elif metric == Metric.MEDIAN_VALUE:
                     stride_metrics[metric.value] = compute_median_value(
-                        stride_data, self.component
+                        stride_data, self.meta.component
                     )
                 elif metric == Metric.STD_VALUE:
                     stride_metrics[metric.value] = compute_std_value(
-                        stride_data, self.component
+                        stride_data, self.meta.component
                     )
                 elif metric == Metric.TOE_OFF_VALUE and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_toe_off_value(
-                        stride_data, toe_off_time, self.component
+                        stride_data, toe_off_time, self.meta.component
                     )
                 elif metric == Metric.STANCE_TIME and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_stance_time(
@@ -299,15 +309,15 @@ class GaitMetricsCalculator:
                     )
                 elif metric == Metric.STANCE_MEAN_VALUE and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_stance_mean_value(
-                        stride_data, toe_off_time, self.component
+                        stride_data, toe_off_time, self.meta.component
                     )
                 elif metric == Metric.STANCE_MEDIAN_VALUE and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_stance_median_value(
-                        stride_data, toe_off_time, self.component
+                        stride_data, toe_off_time, self.meta.component
                     )
                 elif metric == Metric.STANCE_STD_VALUE and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_stance_std_value(
-                        stride_data, toe_off_time, self.component
+                        stride_data, toe_off_time, self.meta.component
                     )
                 elif metric == Metric.SWING_TIME and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_swing_time(
@@ -315,19 +325,27 @@ class GaitMetricsCalculator:
                     )
                 elif metric == Metric.SWING_MEAN_VALUE and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_swing_mean_value(
-                        stride_data, toe_off_time, self.component
+                        stride_data, toe_off_time, self.meta.component
                     )
                 elif metric == Metric.SWING_MEDIAN_VALUE and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_swing_median_value(
-                        stride_data, toe_off_time, self.component
+                        stride_data, toe_off_time, self.meta.component
                     )
                 elif metric == Metric.SWING_STD_VALUE and toe_off_time is not None:
                     stride_metrics[metric.value] = compute_swing_std_value(
-                        stride_data, toe_off_time, self.component
+                        stride_data, toe_off_time, self.meta.component
                     )
 
             all_strides_metrics_list.append(stride_metrics)
         all_strides_metrics = pd.DataFrame(all_strides_metrics_list)
         if output_path is not None:
-            all_strides_metrics.to_csv(output_path, index=False)
+            if not os.path.exists(output_path):
+                os.makedirs(output_path)
+            file_path = (
+                f"{output_path}/{self.meta.orgid}_"
+                f"{self.meta.study}_{self.meta.collection_num}_"
+                f"{self.meta.position}_{self.meta.stream_name}_"
+                f"{self.meta.component}_gait_metrics.csv"
+            )
+            all_strides_metrics.to_csv(file_path, index=True)
         return all_strides_metrics

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -649,7 +649,7 @@ class GaitMetricsCalculator:
 def compute_gait_metrics(
     stream: np.ndarray,
     stride_splits: np.ndarray,
-    position: int,
+    position: str,
     stream_name: str,
     component: str,
     orgid: Optional[str] = None,
@@ -666,7 +666,7 @@ def compute_gait_metrics(
     Args:
         stream (np.ndarray): Kinematics input data.
         stride_splits (np.ndarray): Array of stride splits.
-        position (int): Position identifier, e.g. 'r_shank'
+        position (str): Position identifier, e.g. 'r_shank'
         stream_name (str): Name of the stream.
         component (str): Component to analyze, e.g. 'x', 'knee_flexion'.
         orgid (str, optional): Organization ID.

--- a/cionic/gait_metrics.py
+++ b/cionic/gait_metrics.py
@@ -231,7 +231,7 @@ def compute_std_value(stride_data: np.ndarray, component: str = 'x') -> float:
 
 
 def compute_toe_off_value(
-    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+    stride_data: np.ndarray, toe_off_time: float, component: str = 'x'
 ) -> float:
     """
     Get the value of a component at the toe off time.
@@ -250,9 +250,7 @@ def compute_toe_off_value(
     return stride_data[closest_index][component]
 
 
-def compute_stance_time(
-    stride_data: np.ndarray, toe_off_time: Optional[float]
-) -> float:
+def compute_stance_time(stride_data: np.ndarray, toe_off_time: float) -> float:
     """
     Compute the duration of the stance phase for the stride.
 
@@ -269,7 +267,7 @@ def compute_stance_time(
 
 
 def compute_stance_mean_value(
-    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+    stride_data: np.ndarray, toe_off_time: float, component: str = 'x'
 ) -> float:
     """
     Compute mean value of a component during the stance phase.
@@ -291,7 +289,7 @@ def compute_stance_mean_value(
 
 
 def compute_stance_median_value(
-    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+    stride_data: np.ndarray, toe_off_time: float, component: str = 'x'
 ) -> float:
     """
     Compute median value of a component during the stance phase.
@@ -313,7 +311,7 @@ def compute_stance_median_value(
 
 
 def compute_stance_std_value(
-    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+    stride_data: np.ndarray, toe_off_time: float, component: str = 'x'
 ) -> float:
     """
     Compute standard deviation of a component during the stance phase.
@@ -334,7 +332,7 @@ def compute_stance_std_value(
     return compute_std_value(stance_data, component)
 
 
-def compute_swing_time(stride_data: np.ndarray, toe_off_time: Optional[float]) -> float:
+def compute_swing_time(stride_data: np.ndarray, toe_off_time: float) -> float:
     """
     Compute the duration of the swing phase for the stride.
 
@@ -351,7 +349,7 @@ def compute_swing_time(stride_data: np.ndarray, toe_off_time: Optional[float]) -
 
 
 def compute_swing_mean_value(
-    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+    stride_data: np.ndarray, toe_off_time: float, component: str = 'x'
 ) -> float:
     """
     Compute mean value of a component during the swing phase.
@@ -373,7 +371,7 @@ def compute_swing_mean_value(
 
 
 def compute_swing_median_value(
-    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+    stride_data: np.ndarray, toe_off_time: float, component: str = 'x'
 ) -> float:
     """
     Compute median value of a component during the swing phase.
@@ -395,7 +393,7 @@ def compute_swing_median_value(
 
 
 def compute_swing_std_value(
-    stride_data: np.ndarray, toe_off_time: Optional[float], component: str = 'x'
+    stride_data: np.ndarray, toe_off_time: float, component: str = 'x'
 ) -> float:
     """
     Compute standard deviation of a component during the swing phase.

--- a/cionic/kinematics.py
+++ b/cionic/kinematics.py
@@ -167,7 +167,7 @@ def get_grouped_walking_splits(
     peaks, _ = find_peaks(factor * kinematic_time_series[component], **peak_kwargs)
     splits_timestamps = kinematic_time_series["elapsed_s"][peaks]
     if splits_timestamps.shape[0] < 2:
-        return [()]
+        return [[]]
     median_time_interval = np.median(np.diff(splits_timestamps))
 
     all_grouped_splits = []
@@ -179,9 +179,13 @@ def get_grouped_walking_splits(
             # a split can be no longer than twice the median of splits
             this_group_splits += [this_split, next_split]
         else:
-            all_grouped_splits.append(sorted(list(set(this_group_splits))))
+            group = sorted(list(set(this_group_splits)))
+            if group:
+                all_grouped_splits.append(group)
             this_group_splits = []
-    all_grouped_splits.append(sorted(list(set(this_group_splits))))
+    group = sorted(list(set(this_group_splits)))
+    if group:
+        all_grouped_splits.append(group)
     return all_grouped_splits
 
 

--- a/cionic/kinematics.py
+++ b/cionic/kinematics.py
@@ -141,6 +141,7 @@ def costri(a, b, C):
 def get_grouped_walking_splits(
     kinematic_time_series,
     component="x",
+    factor=1.0,
     peak_kwargs=None,
 ):
     '''
@@ -151,6 +152,7 @@ def get_grouped_walking_splits(
         kinematic_time_series (numpy.ndarray): Kinematic time series data with
             column-accessible components (e.g., 'x', 'y', 'z') and an 'elapsed_s'.
         component (str): The component to analyze for peak detection. Defaults to 'x'.
+        factor (float): Factor to scale the component values for peak detection.
         peak_kwargs (dict, optional): Optional dictionary of arguments to customize
             peak detection behavior.
 
@@ -158,9 +160,11 @@ def get_grouped_walking_splits(
         list[list[float]]: A list of groups, a group is a list of split timestamps
         that occur close together and likely represent a single walking sequence.
     '''
+    if factor != 1.0 and factor != -1.0:
+        raise ValueError(f"factor must be 1.0 or -1.0, got {factor}")
     if not peak_kwargs:
         peak_kwargs = PEAK_KWARGS
-    peaks, _ = find_peaks(kinematic_time_series[component], **peak_kwargs)
+    peaks, _ = find_peaks(factor * kinematic_time_series[component], **peak_kwargs)
     splits_timestamps = kinematic_time_series["elapsed_s"][peaks]
     if splits_timestamps.shape[0] < 2:
         return [()]

--- a/tests/test_metrics_calculator.py
+++ b/tests/test_metrics_calculator.py
@@ -1,0 +1,144 @@
+"""
+Demonstrates and tests usage of the GaitMetricsCalculator and related functions.
+
+This module loads example kinematic data, extracts stride and segment information,
+and computes gait metrics using various configurations. It saves results to CSV
+files for inspection and visualizes stride and toe-off events using matplotlib.
+The examples cover direct class usage, wrapper function calls, and metric subset
+selection, providing practical reference for gait analysis workflows.
+"""
+
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from cionic import api, gait_metrics
+
+
+def get_npz():
+    download = (
+        "cionic/collections/5hnxSDyWEZWDFEDw5pTcoMNhckJeD7N61K_fIpG1qFw/streams/npz"
+    )
+    npzpath = "/tmp/cionic_khe_13.npz"
+    tokenpath = "token.json"
+
+    # download = (
+    #     "cionic/collections/sjqW785pPLuWF-JxsD60r7WNmDS3Xy18p01Nzj7OVRI/streams/npz"
+    # )
+    # npzpath = "cionic_Apollo_Adult_897.npz"
+
+    if os.path.exists(npzpath):
+        os.remove(npzpath)
+
+    _ = api.auth(tokenpath=tokenpath)
+    api.download_npz(npzpath, download, include_gait_splits=True)
+    npz = np.load(npzpath)
+    return npz
+
+
+def main():
+    npz = get_npz()
+
+    for seg in npz['segments']:
+        is_euler = seg['stream'] == 'euler'
+        is_shank = seg['position'].endswith('_shank')
+        is_intervals = seg['stream'] == 'intervals'
+        if is_euler and is_shank:
+            print(f"Kinematics segment: {seg['path']}")
+            stream_seg = seg
+        if is_intervals and is_shank:
+            print(f"Strides segment: {seg['path']}")
+            stride_splits_seg = seg
+
+    # Call the class directly.
+    # Results CSV in tests/test_metrics_output/cionic/khe/3/
+    metrics_calculator = gait_metrics.GaitMetricsCalculator(
+        stream=npz[stream_seg['path']],
+        stride_splits=npz[stride_splits_seg['path']],
+        shank_stream=npz[stream_seg['path']],
+        meta=gait_metrics.Metadata(
+            orgid="cionic",
+            study="khe",
+            collection_num="3",
+            position=stream_seg['position'],
+            stream_name=stream_seg['stream'],
+            component='x',
+        ),
+    )
+    _ = metrics_calculator.calculate_metrics(output_path="tests/test_metrics_output")
+
+    # Call the class directly, leaving out orgid, study, collection_num from Metadata.
+    # Results CSV in tests/test_metrics_output/
+    metrics_calculator = gait_metrics.GaitMetricsCalculator(
+        stream=npz[stream_seg['path']],
+        stride_splits=npz[stride_splits_seg['path']],
+        shank_stream=npz[stream_seg['path']],
+        meta=gait_metrics.Metadata(
+            position=stream_seg['position'],
+            stream_name=stream_seg['stream'],
+            component='x',
+        ),
+    )
+    _ = metrics_calculator.calculate_metrics(output_path="tests/test_metrics_output")
+
+    # Call the class from compute_gait_metrics() wrapper.
+    # Results CSV in tests/test_metrics_output/wrapper/cionic/khe/3/
+    _ = gait_metrics.compute_gait_metrics(
+        stream=npz[stream_seg['path']],
+        stride_splits=npz[stride_splits_seg['path']],
+        position=stream_seg['position'],
+        stream_name=stream_seg['stream'],
+        component='x',
+        orgid="cionic",
+        study="khe",
+        collection_num="3",
+        shank_stream=npz[stream_seg['path']],
+        output_path="tests/test_metrics_output/wrapper",
+    )
+
+    # Call the class from compute_gait_metrics() wrapper,
+    # leaving out orgid, study, collection_num from Metadata.
+    # Results CSV in tests/test_metrics_output/wrapper/
+    _ = gait_metrics.compute_gait_metrics(
+        stream=npz[stream_seg['path']],
+        stride_splits=npz[stride_splits_seg['path']],
+        position=stream_seg['position'],
+        stream_name=stream_seg['stream'],
+        component='x',
+        shank_stream=npz[stream_seg['path']],
+        output_path="tests/test_metrics_output/wrapper",
+    )
+
+    # Call the class from compute_gait_metrics() wrapper,
+    # using a subset of metrics.
+    # Results CSV in tests/test_metrics_output/metrics_subset/
+    metrics = [
+        gait_metrics.Metric.STRIDE_TIME,
+        gait_metrics.Metric.PEAK_VALUE,
+    ]
+    _ = gait_metrics.compute_gait_metrics(
+        stream=npz[stream_seg['path']],
+        stride_splits=npz[stride_splits_seg['path']],
+        position=stream_seg['position'],
+        stream_name=stream_seg['stream'],
+        component='x',
+        shank_stream=npz[stream_seg['path']],
+        metrics=metrics,
+        output_path="tests/test_metrics_output/metrics_subset",
+    )
+
+    _, ax = plt.subplots(figsize=(10, 5))
+    ax.plot("elapsed_s", "x", "", data=npz[stream_seg['path']])
+
+    vline_kwargs = dict(linestyle='--', alpha=0.5)
+    for stride in npz[stride_splits_seg['path']]:
+        ax.axvline(stride['start_s'], color='red', **vline_kwargs)
+        ax.axvline(stride['stop_s'], color='green', zorder=-10)
+    for toe_off_time in metrics_calculator.toe_off_times:
+        ax.axvline(x=toe_off_time, color='gray', **vline_kwargs)
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_metrics_calculator.py
+++ b/tests/test_metrics_calculator.py
@@ -74,6 +74,13 @@ def main():
         ),
     )
     _ = metrics_calculator.calculate_metrics(output_path="tests/test_metrics_output")
+    expected_path = (
+        "tests/test_metrics_output/cionic/khe/3/"
+        "cionic_khe_3_r_shank_euler_x_gait_metrics.csv"
+    )
+    assert os.path.exists(
+        expected_path
+    ), f"Expected output file not found: {expected_path}"
 
     # Call the class directly, leaving out org_shortname, study_shortname,
     # and collection_num from Metadata.
@@ -89,6 +96,10 @@ def main():
         ),
     )
     _ = metrics_calculator.calculate_metrics(output_path="tests/test_metrics_output")
+    expected_path = "tests/test_metrics_output/r_shank_euler_x_gait_metrics.csv"
+    assert os.path.exists(
+        expected_path
+    ), f"Expected output file not found: {expected_path}"
 
     # Call the class from compute_gait_metrics() wrapper.
     # Results CSV in tests/test_metrics_output/wrapper/cionic/khe/3/
@@ -104,6 +115,13 @@ def main():
         shank_stream=npz[stream_seg['path']],
         output_path="tests/test_metrics_output/wrapper",
     )
+    expected_path = (
+        "tests/test_metrics_output/wrapper/cionic/khe/3/"
+        "cionic_khe_3_r_shank_euler_x_gait_metrics.csv"
+    )
+    assert os.path.exists(
+        expected_path
+    ), f"Expected output file not found: {expected_path}"
 
     # Call the class from compute_gait_metrics() wrapper,
     # leaving out org_shortname, study_shortname, collection_num from Metadata.
@@ -117,6 +135,10 @@ def main():
         shank_stream=npz[stream_seg['path']],
         output_path="tests/test_metrics_output/wrapper",
     )
+    expected_path = "tests/test_metrics_output/wrapper/r_shank_euler_x_gait_metrics.csv"
+    assert os.path.exists(
+        expected_path
+    ), f"Expected output file not found: {expected_path}"
 
     # Call the class from compute_gait_metrics() wrapper,
     # using a subset of metrics.
@@ -135,6 +157,12 @@ def main():
         metrics=metrics,
         output_path="tests/test_metrics_output/metrics_subset",
     )
+    expected_path = (
+        "tests/test_metrics_output/metrics_subset/r_shank_euler_x_gait_metrics.csv"
+    )
+    assert os.path.exists(
+        expected_path
+    ), f"Expected output file not found: {expected_path}"
 
     _, ax = plt.subplots(figsize=(10, 5))
     ax.plot("elapsed_s", "x", "", data=npz[stream_seg['path']])

--- a/tests/test_metrics_calculator.py
+++ b/tests/test_metrics_calculator.py
@@ -43,16 +43,25 @@ def get_npz():
 def main():
     npz = get_npz()
 
-    for seg in npz['segments']:
-        is_euler = seg['stream'] == 'euler'
-        is_shank = seg['position'].endswith('_shank')
-        is_intervals = seg['stream'] == 'intervals'
-        if is_euler and is_shank:
-            print(f"Kinematics segment: {seg['path']}")
-            stream_seg = seg
-        if is_intervals and is_shank:
-            print(f"Strides segment: {seg['path']}")
-            stride_splits_seg = seg
+    segs = npz['segments']
+    euler_shank_mask = (segs['stream'] == 'euler') & np.char.endswith(
+        segs['position'], '_shank'
+    )
+    intervals_shank_mask = np.char.endswith(
+        segs['position'], '_shank'
+    ) & np.char.endswith(segs['path'], '_paired_stride_splits')
+
+    stream_seg = segs[euler_shank_mask]
+    stride_splits_seg = segs[intervals_shank_mask]
+
+    assert stream_seg.shape[0] == 1, f"Expected 1 stream_seg, got {stream_seg.shape[0]}"
+    assert (
+        stride_splits_seg.shape[0] == 1
+    ), f"Expected 1 stride_splits_seg, got {stride_splits_seg.shape[0]}"
+
+    stream_seg = stream_seg[0]
+    stride_splits_seg = stride_splits_seg[0]
+    print(f"Strides segment: {stride_splits_seg['path']}")
 
     # Call the class directly.
     # Results CSV in tests/test_metrics_output/cionic/khe/3/

--- a/tests/test_metrics_calculator.py
+++ b/tests/test_metrics_calculator.py
@@ -26,11 +26,6 @@ def get_npz():
     npzpath = "/tmp/cionic_khe_13.npz"
     tokenpath = "token.json"
 
-    # download = (
-    #     "cionic/collections/sjqW785pPLuWF-JxsD60r7WNmDS3Xy18p01Nzj7OVRI/streams/npz"
-    # )
-    # npzpath = "cionic_Apollo_Adult_897.npz"
-
     if os.path.exists(npzpath):
         os.remove(npzpath)
 

--- a/tests/test_metrics_calculator.py
+++ b/tests/test_metrics_calculator.py
@@ -6,6 +6,9 @@ and computes gait metrics using various configurations. It saves results to CSV
 files for inspection and visualizes stride and toe-off events using matplotlib.
 The examples cover direct class usage, wrapper function calls, and metric subset
 selection, providing practical reference for gait analysis workflows.
+
+Example usage:
+    python tests/test_metrics_calculator.py
 """
 
 import os

--- a/tests/test_metrics_calculator.py
+++ b/tests/test_metrics_calculator.py
@@ -61,8 +61,8 @@ def main():
         stride_splits=npz[stride_splits_seg['path']],
         shank_stream=npz[stream_seg['path']],
         meta=gait_metrics.Metadata(
-            orgid="cionic",
-            study="khe",
+            org_shortname="cionic",
+            study_shortname="khe",
             collection_num="3",
             position=stream_seg['position'],
             stream_name=stream_seg['stream'],
@@ -71,7 +71,8 @@ def main():
     )
     _ = metrics_calculator.calculate_metrics(output_path="tests/test_metrics_output")
 
-    # Call the class directly, leaving out orgid, study, collection_num from Metadata.
+    # Call the class directly, leaving out org_shortname, study_shortname,
+    # and collection_num from Metadata.
     # Results CSV in tests/test_metrics_output/
     metrics_calculator = gait_metrics.GaitMetricsCalculator(
         stream=npz[stream_seg['path']],
@@ -93,15 +94,15 @@ def main():
         position=stream_seg['position'],
         stream_name=stream_seg['stream'],
         component='x',
-        orgid="cionic",
-        study="khe",
+        org_shortname="cionic",
+        study_shortname="khe",
         collection_num="3",
         shank_stream=npz[stream_seg['path']],
         output_path="tests/test_metrics_output/wrapper",
     )
 
     # Call the class from compute_gait_metrics() wrapper,
-    # leaving out orgid, study, collection_num from Metadata.
+    # leaving out org_shortname, study_shortname, collection_num from Metadata.
     # Results CSV in tests/test_metrics_output/wrapper/
     _ = gait_metrics.compute_gait_metrics(
         stream=npz[stream_seg['path']],


### PR DESCRIPTION
### What it does
This new module provides tools for calculating gait metrics from kinematic data streams.

It processes stride-based movement data, computes a variety of temporal and spatial metrics, and outputs results to CSV. The module supports flexible metric selection and optional toe-off event detection. It is designed for use in gait analysis studies, biomechanics research, and clinical movement assessments.

Typical usage involves providing a kinematic data stream, stride boundaries, and optional metadata. The module extracts stride segments, computes metrics such as stride time, cadence, peak/trough values, and stance/swing phase statistics, and saves the results to disk for further analysis.

Output:
    CSV file containing gait metrics for each stride. Each row represents a stride
    with columns for start time, stop time, elapsed time, and computed metrics.

Available metrics include:
    - stride_time: Duration of the stride.
    - cadence: Steps per minute.
    - peak_value: Maximum value of the component during the stride.
    - trough_value: Minimum value of the component during the stride.
    - start_heel_strike_value: Value at the start of the stride.
    - stop_heel_strike_value: Value at the end of the stride.
    - mean_value: Mean value during the stride.
    - median_value: Median value during the stride.
    - std_value: Standard deviation during the stride.
    - toe_off_value: Value at the toe-off event.
    - stance_time: Duration of the stance phase.
    - stance_mean_value: Mean value during stance phase.
    - stance_median_value: Median value during stance phase.
    - stance_std_value: Standard deviation during stance phase.
    - swing_time: Duration of the swing phase.
    - swing_mean_value: Mean value during swing phase.
    - swing_median_value: Median value during swing phase.
    - swing_std_value: Standard deviation during swing phase.

### How I tested it
Wrote the accompanying `tests/test_metrics_calculator.py` script. It loads example kinematic data, extracts stride and segment information, and computes gait metrics using various configurations. It saves results to CSV files for inspection and visualizes stride and toe-off events using matplotlib. The examples cover direct class usage, wrapper function calls, and metric subset selection, providing practical reference for gait analysis workflows.

Also, manually compared results of the first stride of khe 13 from the output CSV to a quick and dirty Jupyter implementation.