### PR TITLE
Ren/npz downloader

### DIFF
--- a/cionic/api.py
+++ b/cionic/api.py
@@ -353,6 +353,7 @@ def download_file(
 
     Args:
         destpath (str): The local file path where the downloaded content will be saved.
+        overwrite (bool): If True, overwrite the file if it already exists.
         url (str): The URL to download the content from.
         headers (dict, optional): Optional HTTP headers to include in the request.
 
@@ -380,13 +381,32 @@ def download_npz_from_metadata(
     orgid: str,
     studyid: str,
     collection_num: int,
+    tokenpath: str,
     outdir: str = '.',
     overwrite: bool = False,
     segmented: bool = False,
     include_eulers: bool = True,
     include_gait_splits: bool = True,
-    tokenpath: str = None,
 ) -> np.lib.npyio.NpzFile:
+    """
+    Downloads a .npz file associated with a specific org, study, and collection and
+    loads it. User friendly version.
+
+    Args:
+        orgid (str): Organization ID.
+        studyid (str): Short name of the study.
+        collection_num (int): Collection number within the study.
+        tokenpath (str): Path to the authentication token file. Must be specified.
+        outdir (str, optional): Output directory for the downloaded file.
+        overwrite (bool, optional): Whether to overwrite the file if it exists.
+        segmented (bool, optional): If True, loads and returns segmented data.
+        include_eulers (bool, optional): Whether to include Eulers in the download.
+        include_gait_splits (bool, optional): Whether to include gait splits in
+            the download.
+
+    Returns:
+        np.lib.npyio.NpzFile: Loaded .npz file.
+    """
     if tokenpath is None:
         raise ValueError("tokenpath must be specified to download NPZ from metadata.")
 
@@ -447,6 +467,9 @@ def download_npz(
     Args:
         destpath (str): The local file path where the .npz file will be saved.
         urlpath (str): The URL or identifier used to locate the .npz file.
+        overwrite (bool): If True, overwrite the file if it already exists.
+        include_eulers (bool): Whether to include Eulers in the download.
+        include_gait_splits (bool): Whether to include gait splits in the download.
 
     Returns:
         None

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -411,34 +411,14 @@ def download_npz_from_metadata(
         raise ValueError("tokenpath must be specified to download NPZ from metadata.")
 
     auth(tokenpath=tokenpath)
-    studies = get_cionic(f"{orgid}/studies")
-
-    sxid = None
-    for _, s in enumerate(studies):
-        if studyid == s['shortname']:
-            sxid = s['xid']
-
-    if sxid is None:
-        raise ValueError(f"Study [{studyid}] not found for org [{orgid}]")
-
-    collections = get_cionic(f"{orgid}/collections?sxid={sxid}")
-    collection_found = False
-    for collection in collections:
-        if collection['num'] == collection_num:
-            collection_found = True
-            break
-
-    if not collection_found:
-        raise ValueError(
-            f"Collection number [{collection_num}] not found for study [{studyid}]"
-        )
+    kwargs = {"study": studyid, "num": collection_num}
+    (collection,) = get_cionic(f'{orgid}/collections', **kwargs)
 
     urlpath = f"{orgid}/collections/{collection['xid']}/streams/npz"
     destpath = (
         f"{outdir}/{orgid}/{studyid}/{collection_num}/"
         f"{orgid}_{studyid}_{collection_num}.npz"
     )
-
 
     download_npz(
         destpath=destpath,

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -439,7 +439,6 @@ def download_npz_from_metadata(
         f"{orgid}_{studyid}_{collection_num}.npz"
     )
 
-    pathlib.Path(destpath).parent.mkdir(parents=True, exist_ok=True)
 
     download_npz(
         destpath=destpath,

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -413,6 +413,7 @@ def download_npz_from_metadata(
     auth(tokenpath=tokenpath)
     studies = get_cionic(f"{orgid}/studies")
 
+    sxid = None
     for _, s in enumerate(studies):
         if studyid == s['shortname']:
             sxid = s['xid']

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -378,8 +378,8 @@ def download_file(
 
 
 def download_npz_from_metadata(
-    orgid: str,
-    studyid: str,
+    org_shortname: str,
+    study_shortname: str,
     collection_num: int,
     tokenpath: str,
     outdir: str = '.',
@@ -393,8 +393,8 @@ def download_npz_from_metadata(
     loads it. User friendly version.
 
     Args:
-        orgid (str): Organization ID.
-        studyid (str): Short name of the study.
+        org_shortname (str): Organization ID.
+        study_shortname (str): Short name of the study.
         collection_num (int): Collection number within the study.
         tokenpath (str): Path to the authentication token file. Must be specified.
         outdir (str, optional): Output directory for the downloaded file.
@@ -411,13 +411,13 @@ def download_npz_from_metadata(
         raise ValueError("tokenpath must be specified to download NPZ from metadata.")
 
     auth(tokenpath=tokenpath)
-    kwargs = {"study": studyid, "num": collection_num}
-    (collection,) = get_cionic(f'{orgid}/collections', **kwargs)
+    kwargs = {"study": study_shortname, "num": collection_num}
+    (collection,) = get_cionic(f'{org_shortname}/collections', **kwargs)
 
-    urlpath = f"{orgid}/collections/{collection['xid']}/streams/npz"
+    urlpath = f"{org_shortname}/collections/{collection['xid']}/streams/npz"
     destpath = (
-        f"{outdir}/{orgid}/{studyid}/{collection_num}/"
-        f"{orgid}_{studyid}_{collection_num}.npz"
+        f"{outdir}/{org_shortname}/{study_shortname}/{collection_num}/"
+        f"{org_shortname}_{study_shortname}_{collection_num}.npz"
     )
 
     download_npz(

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -345,7 +345,9 @@ def package_npz(segments, npzdir, npzpath, segsuffix=''):
         print("study package complete", file=sys.stderr)
 
 
-def download_file(destpath: str, url: str, headers: dict = None) -> bool:
+def download_file(
+    destpath: str, url: str, overwrite: bool = False, headers: dict = None
+) -> bool:
     """
     Download the content from the given URL and save it to the destination path.
 
@@ -361,7 +363,7 @@ def download_file(destpath: str, url: str, headers: dict = None) -> bool:
         headers = {}
     destpath = ensure_parent(destpath)
 
-    if destpath.exists():
+    if destpath.exists() and not overwrite:
         print(f"already exists {destpath}", file=sys.stderr)
         return False
 
@@ -374,8 +376,70 @@ def download_file(destpath: str, url: str, headers: dict = None) -> bool:
     return True
 
 
+def download_npz_from_metadata(
+    orgid: str,
+    studyid: str,
+    collection_num: int,
+    outdir: str = '.',
+    overwrite: bool = False,
+    segmented: bool = False,
+    include_eulers: bool = True,
+    include_gait_splits: bool = True,
+    tokenpath: str = None,
+) -> np.lib.npyio.NpzFile:
+    if tokenpath is None:
+        raise ValueError("tokenpath must be specified to download NPZ from metadata.")
+
+    auth(tokenpath=tokenpath)
+    studies = get_cionic(f"{orgid}/studies")
+
+    for _, s in enumerate(studies):
+        if studyid == s['shortname']:
+            sxid = s['xid']
+
+    if sxid is None:
+        raise ValueError(f"Study [{studyid}] not found for org [{orgid}]")
+
+    collections = get_cionic(f"{orgid}/collections?sxid={sxid}")
+    collection_found = False
+    for collection in collections:
+        if collection['num'] == collection_num:
+            collection_found = True
+            break
+
+    if not collection_found:
+        raise ValueError(
+            f"Collection number [{collection_num}] not found for study [{studyid}]"
+        )
+
+    urlpath = f"{orgid}/collections/{collection['xid']}/streams/npz"
+    destpath = (
+        f"{outdir}/{orgid}/{studyid}/{collection_num}/"
+        f"{orgid}_{studyid}_{collection_num}.npz"
+    )
+
+    pathlib.Path(destpath).parent.mkdir(parents=True, exist_ok=True)
+
+    download_npz(
+        destpath=destpath,
+        urlpath=urlpath,
+        overwrite=overwrite,
+        include_eulers=include_eulers,
+        include_gait_splits=include_gait_splits,
+    )
+
+    if segmented:
+        return segmenter.load_segmented(destpath)
+    else:
+        return np.load(destpath)
+
+
 def download_npz(
-    destpath: str, urlpath: str, include_eulers=True, include_gait_splits=True
+    destpath: str,
+    urlpath: str,
+    overwrite: bool = False,
+    include_eulers: bool = True,
+    include_gait_splits: bool = True,
 ) -> None:
     """
     Downloads a .npz file from a specified URL path and saves it to the destpath.
@@ -387,8 +451,9 @@ def download_npz(
     Returns:
         None
     """
-    npz = get_cionic(urlpath)
-    status = download_file(destpath, npz['streams.npz'])
+    npz_dict = get_cionic(urlpath)
+
+    status = download_file(destpath, npz_dict['streams.npz'], overwrite=overwrite)
     if status is False:
         return
     if include_eulers:


### PR DESCRIPTION
### What it is
Adding a user friendly `api.download_npz_from_metadata()` to fetch npzs by passing orgid, studyid, and collection number.

### How I tested it
I opted to not commit the following test code, but I tested with this

```
from cionic import api

def main():
    npz = api.download_npz_from_metadata(
        orgid="cionic",
        studyid="khe",
        collection_num=13,
        tokenpath="token.json",
        outdir="tests/test_npz_from_metadata",
        overwrite=True,
    )
    print('Downloaded NPZ files:')
    print(npz.files)

    npz_seg = api.download_npz_from_metadata(
        orgid="cionic",
        studyid="khe",
        collection_num=13,
        tokenpath="token.json",
        outdir="tests/test_npz_from_metadata",
        overwrite=True,
        segmented=True,
    )
    print('Downloaded NPZ files (segmented):')
    print(npz_seg.files)


if __name__ == "__main__":
    main()
```

Results are same as pulling in the tedious way.