### PR TITLE
more user-friendly files download to pair with the npz download

### DIFF
--- a/cionic/api.py
+++ b/cionic/api.py
@@ -482,20 +482,27 @@ def download_files_from_metadata(
         study_shortname (str): Short name of the study.
         collection_num (int): Collection number within the study.
         tokenpath (str): Path to the authentication token file.
-        outdir (str, optional): Base output directory for downloaded files. Defaults to current directory.
-        include (list, optional): List of file extensions to include (e.g., ['.npz', '.json']).
+        outdir (str, optional): Base output directory for downloaded files.
+            Defaults to current directory.
+        include (list, optional): List of file extensions to include
+            (e.g., ['.npz', '.json']).
         exclude (list, optional): List of file extensions to exclude.
 
     Returns:
-        tuple[str, str]: Tuple of (API urlpath, local destination path) used for the download.
+        tuple[str, str]: Tuple of (API urlpath, local destination path) used
+            for the download.
 
     """
     auth(tokenpath=tokenpath)
-    collections = get_cionic(f'{org_shortname}/collections', study=study_shortname, num=collection_num)
+    collections = get_cionic(
+        f'{org_shortname}/collections', study=study_shortname, num=collection_num
+    )
     if not isinstance(collections, (list, tuple)):
-        raise ValueError(f"Expected get_cionic to return a list or tuple, got {type(collections).__name__}")
+        raise ValueError(f"Expected a list or tuple, got {type(collections).__name__}")
     if len(collections) != 1:
-        raise ValueError(f"Expected exactly one collection, got {len(collections)}. Collections: {collections}")
+        raise ValueError(
+            f"Expected 1 collection, got {len(collections)}. Got: {collections}"
+        )
     collection = collections[0]
     urlpath = f'{org_shortname}/collections/{collection["xid"]}/files'
     destpath = f'{outdir}/{org_shortname}/{study_shortname}/{collection_num}/'

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -489,8 +489,6 @@ def download_files_from_metadata(
     Returns:
         tuple[str, str]: Tuple of (API urlpath, local destination path) used for the download.
 
-    Raises:
-        FileNotFoundError: If the token file doesn't exist.
     """
     auth(tokenpath=tokenpath)
     (collection,) = get_cionic(f'{org_shortname}/collections', study=study_shortname, num=collection_num)

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -493,17 +493,13 @@ def download_files_from_metadata(
             for the download.
 
     """
+    if tokenpath is None:
+        raise ValueError("tokenpath must be specified to download NPZ from metadata.")
+
     auth(tokenpath=tokenpath)
-    collections = get_cionic(
-        f'{org_shortname}/collections', study=study_shortname, num=collection_num
-    )
-    if not isinstance(collections, (list, tuple)):
-        raise ValueError(f"Expected a list or tuple, got {type(collections).__name__}")
-    if len(collections) != 1:
-        raise ValueError(
-            f"Expected 1 collection, got {len(collections)}. Got: {collections}"
-        )
-    collection = collections[0]
+    kwargs = {"study": study_shortname, "num": collection_num}
+    (collection,) = get_cionic(f'{org_shortname}/collections', **kwargs)
+
     urlpath = f'{org_shortname}/collections/{collection["xid"]}/files'
     destpath = f'{outdir}/{org_shortname}/{study_shortname}/{collection_num}/'
 

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -491,7 +491,12 @@ def download_files_from_metadata(
 
     """
     auth(tokenpath=tokenpath)
-    (collection,) = get_cionic(f'{org_shortname}/collections', study=study_shortname, num=collection_num)
+    collections = get_cionic(f'{org_shortname}/collections', study=study_shortname, num=collection_num)
+    if not isinstance(collections, (list, tuple)):
+        raise ValueError(f"Expected get_cionic to return a list or tuple, got {type(collections).__name__}")
+    if len(collections) != 1:
+        raise ValueError(f"Expected exactly one collection, got {len(collections)}. Collections: {collections}")
+    collection = collections[0]
     urlpath = f'{org_shortname}/collections/{collection["xid"]}/files'
     destpath = f'{outdir}/{org_shortname}/{study_shortname}/{collection_num}/'
 

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -465,6 +465,42 @@ def download_npz(
         include_gait_splits_to_npz(destpath)
 
 
+def download_files_from_metadata(
+    org_shortname: str,
+    study_shortname: str,
+    collection_num: int,
+    tokenpath: str,
+    outdir: str = '.',
+    include: list = None,
+    exclude: list = None,
+) -> tuple[str, str]:
+    """
+    Downloads files from a collection using metadata, with optional file filtering.
+
+    Args:
+        org_shortname (str): Organization ID.
+        study_shortname (str): Short name of the study.
+        collection_num (int): Collection number within the study.
+        tokenpath (str): Path to the authentication token file.
+        outdir (str, optional): Base output directory for downloaded files. Defaults to current directory.
+        include (list, optional): List of file extensions to include (e.g., ['.npz', '.json']).
+        exclude (list, optional): List of file extensions to exclude.
+
+    Returns:
+        tuple[str, str]: Tuple of (API urlpath, local destination path) used for the download.
+
+    Raises:
+        FileNotFoundError: If the token file doesn't exist.
+    """
+    auth(tokenpath=tokenpath)
+    (collection,) = get_cionic(f'{org_shortname}/collections', study=study_shortname, num=collection_num)
+    urlpath = f'{org_shortname}/collections/{collection["xid"]}/files'
+    destpath = f'{outdir}/{org_shortname}/{study_shortname}/{collection_num}/'
+
+    download_files(urlpath, destpath, include=include, exclude=exclude)
+    return urlpath, destpath
+
+
 def download_files(urlpath, directory, include=None, exclude=None, ver=apiver):
     results = []
     files = get_cionic(urlpath)


### PR DESCRIPTION
This function is based on the new download_npz_from_metadata function to help with downloading non-npz files using the same syntax