### PR TITLE
pipe peak_kwargs through download_npz_from_metadata()

### DIFF
--- a/cionic/api.py
+++ b/cionic/api.py
@@ -598,6 +598,7 @@ def download_npz_from_metadata(
     segmented: bool = False,
     include_eulers: bool = True,
     include_gait_splits: bool = True,
+    peak_kwargs: dict = None,
 ) -> np.lib.npyio.NpzFile:
     """
     Downloads a .npz file associated with a specific org, study, and collection and
@@ -614,6 +615,7 @@ def download_npz_from_metadata(
         include_eulers (bool, optional): Whether to include Eulers in the download.
         include_gait_splits (bool, optional): Whether to include gait splits in
             the download.
+        peak_kwargs (dict, optional): Additional parameters for peak detection.
 
     Returns:
         np.lib.npyio.NpzFile: Loaded .npz file.
@@ -622,12 +624,17 @@ def download_npz_from_metadata(
         f"{outdir}/{org_shortname}/{study_shortname}/{collection_num}/"
         f"{org_shortname}_{study_shortname}_{collection_num}.npz"
     )
-    if os.path.exists(destpath) and not overwrite:
+    if os.path.exists(destpath) and not overwrite and not segmented:
         print(f"already exists {destpath}", file=sys.stderr)
-        if segmented:
-            return segmenter.load_segmented(destpath)
-        else:
-            return np.load(destpath)
+        return np.load(destpath)
+    elif (
+        os.path.exists(destpath.replace('.npz', '_seg.npz'))
+        and not overwrite
+        and segmented
+    ):
+        print(f"already exists {destpath.replace('.npz', '_seg.npz')}", file=sys.stderr)
+        return np.load(destpath.replace('.npz', '_seg.npz'))
+
     if tokenpath is None:
         raise ValueError("tokenpath must be specified to download NPZ from metadata.")
 
@@ -643,6 +650,7 @@ def download_npz_from_metadata(
         overwrite=overwrite,
         include_eulers=include_eulers,
         include_gait_splits=include_gait_splits,
+        peak_kwargs=peak_kwargs,
     )
 
     if segmented:
@@ -657,6 +665,7 @@ def download_npz(
     overwrite: bool = False,
     include_eulers: bool = True,
     include_gait_splits: bool = True,
+    peak_kwargs: dict = None,
 ) -> None:
     """
     Downloads a .npz file from a specified URL path and saves it to the destpath.
@@ -667,6 +676,7 @@ def download_npz(
         overwrite (bool): If True, overwrite the file if it already exists.
         include_eulers (bool): Whether to include Eulers in the download.
         include_gait_splits (bool): Whether to include gait splits in the download.
+        peak_kwargs (dict, optional): Additional parameters for peak detection.
 
     Returns:
         None
@@ -679,7 +689,7 @@ def download_npz(
     if include_eulers:
         include_eulers_to_npz(destpath)
     if include_gait_splits:
-        include_gait_splits_to_npz(destpath)
+        include_gait_splits_to_npz(destpath, peak_kwargs=peak_kwargs)
 
 
 def download_files_from_metadata(
@@ -819,13 +829,14 @@ def include_eulers_to_npz(destpath: str) -> None:
     add_arrays_to_npz_and_store(npz, array_dict, destpath)
 
 
-def include_gait_splits_to_npz(destpath: str) -> None:
+def include_gait_splits_to_npz(destpath: str, peak_kwargs: dict = None) -> None:
     '''
     Loads a NumPy .npz file from the specified path, computes gait split arrays and
     updated segments, and adds them to the .npz file.
 
     Args:
         destpath (str): The file path to the .npz file to be updated.
+        peak_kwargs (dict, optional): Additional parameters for peak detection.
 
     Returns:
         None
@@ -839,22 +850,22 @@ def include_gait_splits_to_npz(destpath: str) -> None:
         print(f"File {destpath} not found.", file=sys.stderr)
         return
 
-    new_files, updated_segments = get_splits_arrays_and_segments(npz=npz)
+    new_files, updated_segments = get_splits_arrays_and_segments(
+        npz=npz, peak_kwargs=peak_kwargs
+    )
 
     array_dict = {**new_files, 'segments': updated_segments}
     add_arrays_to_npz_and_store(npz, array_dict, destpath)
 
 
-def create_new_segment_helper(
-    segment: np.void, path: str, stream: str = 'intervals'
-) -> np.void:
+def create_new_segment_helper(segment: np.void, path: str, stream: str) -> np.void:
     """
     Create a new segment structured array entry for walking intervals.
 
     Args:
         segment (np.void): Existing segment structured array entry.
         path (str): Path for the new segment.
-        stream (str): Stream name for the new segment (default 'intervals').
+        stream (str): Stream name for the new segment.
 
     Returns:
         np.void: New segment structured array entry with updated fields.
@@ -868,7 +879,7 @@ def create_new_segment_helper(
 
 
 def get_splits_arrays_and_segments(
-    npz: np.lib.npyio.NpzFile,
+    npz: np.lib.npyio.NpzFile, peak_kwargs: dict = None
 ) -> tuple[dict[str, np.recarray], np.recarray]:
     '''
     Processes segments in the given npz file, generating new arrays and segments
@@ -876,6 +887,7 @@ def get_splits_arrays_and_segments(
 
     Args:
         npz (np.lib.npyio.NpzFile): NPZ file containing 'segments' and time series.
+        peak_kwargs (dict, optional): Additional parameters for peak detection.
 
     Returns:
         tuple[dict[str, np.recarray], np.recarray]: A dictionary of new arrays keyed
@@ -891,11 +903,14 @@ def get_splits_arrays_and_segments(
         if is_shank and is_euler:
             grouped_walking_periods = get_grouped_walking_periods_as_array(
                 kinematic_time_series=npz[segment['path']],
+                peak_kwargs=peak_kwargs,
             )
             path = f'{segment["device"]}_walking_periods'
             new_files[path] = grouped_walking_periods
 
-            new_segment = create_new_segment_helper(segment=segment, path=path)
+            new_segment = create_new_segment_helper(
+                segment=segment, path=path, stream='walking_periods'
+            )
             new_segments.append(new_segment)
 
         if (is_shank or is_thigh) and is_euler:
@@ -904,11 +919,14 @@ def get_splits_arrays_and_segments(
                 component="x",
                 n_start_remove=0,
                 n_stop_remove=0,
+                peak_kwargs=peak_kwargs,
             )
             path = f'{segment["device"]}_paired_stride_splits'
             new_files[path] = paired_stride_splits
 
-            new_segment = create_new_segment_helper(segment=segment, path=path)
+            new_segment = create_new_segment_helper(
+                segment=segment, path=path, stream='paired_stride_splits'
+            )
             new_segments.append(new_segment)
 
     if len(new_files) == 0:
@@ -952,7 +970,7 @@ def get_grouped_walking_periods_as_array(
             (group[0], group[-1], group[-1] - group[0])
             for group in grouped_walking_periods
         ],
-        dtype=np.dtype([('start_s', 'f8'), ('stop_s', 'f8'), ('elapsed_s', 'f8')]),
+        dtype=np.dtype([('start_s', 'f8'), ('stop_s', 'f8'), ('duration_s', 'f8')]),
     )
     return grouped_walking_periods_array
 
@@ -986,7 +1004,7 @@ def get_paired_stride_splits_as_array(
     )
     paired_stride_splits_array = np.array(
         [(start, stop, stop - start) for start, stop in paired_stride_splits],
-        dtype=np.dtype([('start_s', 'f8'), ('stop_s', 'f8'), ('elapsed_s', 'f8')]),
+        dtype=np.dtype([('start_s', 'f8'), ('stop_s', 'f8'), ('duration_s', 'f8')]),
     )
     return paired_stride_splits_array
 


### PR DESCRIPTION
resolves #33 

## Pull Request Overview

This PR enables passing peak detection parameters through the download NPZ functions by adding a `peak_kwargs` parameter that flows from `download_npz_from_metadata()` down to the underlying gait analysis functions. The changes also include improvements to file handling logic and field naming consistency.

Key changes:
- Added `peak_kwargs` parameter threading through download functions to enable customizable peak detection
- Improved file existence checking logic for segmented vs non-segmented files
- Renamed field from `elapsed_s` to `duration_s` for better clarity in time interval arrays

A runnable snippet is shown below. The two figures show that different splits result based on `prominence = 30` and `prominence = 70`.

<img width="830" height="418" alt="Screenshot 2025-08-28 at 1 11 31 PM" src="https://github.com/user-attachments/assets/e4c87ecf-9e29-4060-b0d6-51832d3ccb85" />
<img width="831" height="419" alt="Screenshot 2025-08-28 at 1 11 56 PM" src="https://github.com/user-attachments/assets/0776e5f7-8005-4151-943f-bf2b8e2232d1" />

```
from matplotlib import pyplot as plt
from cionic import api

pd.set_option('display.max_columns', None)
pd.set_option('display.max_rows', None)

org_shortname = "cionic"
study_shortname = "reference_colls"
collection_num = 1
overwrite = True
segmented = False
tokenpath = "/home/jovyan/token.json"

peak_kwargs = {'distance': 50, 'prominence': 30}
# peak_kwargs = {'distance': 50, 'prominence': 70}

npz = api.download_npz_from_metadata(
    org_shortname=org_shortname,
    study_shortname=study_shortname,
    collection_num=collection_num,
    outdir='../recordings',
    overwrite=overwrite,
    segmented=segmented,
    tokenpath=tokenpath,
    peak_kwargs=peak_kwargs,
)

_, ax = plt.subplots(figsize=(10, 5))
stream = npz["SI_34900473_fquat2euler"]
stride_splits = npz["SI_34900473_paired_stride_splits"]
ax.plot(stream["elapsed_s"], stream["x"])
for i in range(stride_splits.shape[0]):
    ax.axvline(stride_splits[i]["start_s"], alpha=0.3, color="green", ls="--")
    ax.axvline(stride_splits[i]["stop_s"], alpha=0.3, color="red", ls="--")
plt.show()
```