### PR TITLE
updating peak_kwarg defaults

### DIFF
--- a/cionic/kinematics.py
+++ b/cionic/kinematics.py
@@ -165,9 +165,11 @@ def get_grouped_walking_splits(
     if not peak_kwargs:
         peak_kwargs = PEAK_KWARGS
     peaks, _ = find_peaks(factor * kinematic_time_series[component], **peak_kwargs)
-    FIRST_INDEX = 0
-    LAST_INDEX = kinematic_time_series.shape[0] - 1
-    valid_peaks = (peaks != FIRST_INDEX) & (peaks != LAST_INDEX)
+    # Remove first and last index from peaks. Highly unlikely true peak is at first
+    # or last sample. Otherwise, typically results in bad splits that should be removed.
+    first_index = 0
+    last_index = kinematic_time_series.shape[0] - 1
+    valid_peaks = (peaks != first_index) & (peaks != last_index)
     peaks = peaks[valid_peaks]
 
     splits_timestamps = kinematic_time_series["elapsed_s"][peaks]

--- a/cionic/kinematics.py
+++ b/cionic/kinematics.py
@@ -20,7 +20,7 @@ from scipy.stats import ttest_ind
 
 from cionic import tools
 
-PEAK_KWARGS = {'distance': 50, 'prominence': 20, 'height': 15}
+PEAK_KWARGS = {'distance': 50, 'prominence': 30}
 
 
 def GaitCycleAxis():
@@ -165,6 +165,9 @@ def get_grouped_walking_splits(
     if not peak_kwargs:
         peak_kwargs = PEAK_KWARGS
     peaks, _ = find_peaks(factor * kinematic_time_series[component], **peak_kwargs)
+    valid_peaks = (peaks != 0) & (peaks != kinematic_time_series.shape[0] - 1)
+    peaks = peaks[valid_peaks]
+
     splits_timestamps = kinematic_time_series["elapsed_s"][peaks]
     if splits_timestamps.shape[0] < 2:
         return [[]]

--- a/cionic/kinematics.py
+++ b/cionic/kinematics.py
@@ -165,7 +165,9 @@ def get_grouped_walking_splits(
     if not peak_kwargs:
         peak_kwargs = PEAK_KWARGS
     peaks, _ = find_peaks(factor * kinematic_time_series[component], **peak_kwargs)
-    valid_peaks = (peaks != 0) & (peaks != kinematic_time_series.shape[0] - 1)
+    FIRST_INDEX = 0
+    LAST_INDEX = kinematic_time_series.shape[0] - 1
+    valid_peaks = (peaks != FIRST_INDEX) & (peaks != LAST_INDEX)
     peaks = peaks[valid_peaks]
 
     splits_timestamps = kinematic_time_series["elapsed_s"][peaks]


### PR DESCRIPTION
resolves #35 

## Pull Request Overview

This PR updates the default parameters for peak detection in gait cycle analysis and improves peak filtering logic. The new parameters were much more forgiving for Parkinson's gait analysis and won't impact any analysis for higher functioning/neurotypical gait. The changes address issue #35 by modifying the PEAK_KWARGS defaults and adding validation to exclude boundary peaks.

- Modified PEAK_KWARGS to remove 'height' parameter and increase 'prominence' from 20 to 30
- Added filtering logic to exclude peaks at the first and last indices of the time series