### PR TITLE
Ren/segments side

### DIFF
--- a/cionic/api.py
+++ b/cionic/api.py
@@ -674,6 +674,7 @@ def download_npz(
     npz_dict = get_cionic(urlpath)
 
     status = download_file(destpath, npz_dict['streams.npz'], overwrite=overwrite)
+    add_side_column_to_segments(destpath)
     if status is False:
         return
     if include_eulers:
@@ -788,6 +789,55 @@ def add_arrays_to_npz_and_store(
             else:
                 with outzf.open(f"{file}.npy", mode='w') as fp:
                     np.save(fp, arr, allow_pickle=False)
+
+
+def add_side_column_to_segments(destpath: str) -> None:
+    """
+    Load a .npz file, add a 'side' column to the segments array,
+    and save the updated arrays back to the .npz file.
+
+    Args:
+        destpath (str): Path to the .npz file to update.
+
+    Returns:
+        None
+    """
+    try:
+        npz = np.load(destpath)
+    except FileNotFoundError:
+        print(f"File {destpath} not found.", file=sys.stderr)
+        return
+
+    if npz['segments'] is None:
+        print(f"No segments found in {destpath}.", file=sys.stderr)
+        return
+
+    # Add 'side' column to segments
+    new_dtype = []
+    side_added = False
+    for name, dtype in npz["segments"].dtype.descr:
+        # 'side' column added before 'position'
+        if name == "position":
+            new_dtype.append(('side', 'U8'))
+            side_added = True
+        new_dtype.append((name, dtype))
+
+    if side_added is False:
+        new_dtype.append(('side', 'U8'))
+
+    segments = np.recarray(npz["segments"].shape, dtype=new_dtype)
+
+    for name in npz["segments"].dtype.names:
+        segments[name] = npz["segments"][name]
+
+    sides = np.full(segments.shape, None)  # start with None everywhere
+    sides[np.char.startswith(segments["position"], "r_")] = "right"
+    sides[np.char.startswith(segments["position"], "l_")] = "left"
+
+    segments["side"] = sides
+
+    # Save updated segments back to the .npz file
+    add_arrays_to_npz_and_store(npz, {'segments': segments}, destpath)
 
 
 def include_eulers_to_npz(destpath: str) -> None:

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -818,7 +818,7 @@ def add_side_column_to_segments(destpath: str) -> None:
         print(f"File {destpath} not found.", file=sys.stderr)
         return
 
-    if npz['segments'] is None:
+    if 'segments' not in npz or npz['segments'] is None:
         print(f"No segments found in {destpath}.", file=sys.stderr)
         return
 

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -832,7 +832,7 @@ def add_side_column_to_segments(destpath: str) -> None:
             side_added = True
         new_dtype.append((name, dtype))
 
-    if side_added is False:
+    if not side_added:
         new_dtype.append(("side", "U8"))
 
     segments = np.recarray(npz["segments"].shape, dtype=new_dtype)

--- a/cionic/api.py
+++ b/cionic/api.py
@@ -674,13 +674,13 @@ def download_npz(
     npz_dict = get_cionic(urlpath)
 
     status = download_file(destpath, npz_dict['streams.npz'], overwrite=overwrite)
-    add_side_column_to_segments(destpath)
     if status is False:
         return
     if include_eulers:
         include_eulers_to_npz(destpath)
     if include_gait_splits:
         include_gait_splits_to_npz(destpath)
+    add_side_column_to_segments(destpath)
 
 
 def download_files_from_metadata(
@@ -818,19 +818,19 @@ def add_side_column_to_segments(destpath: str) -> None:
     for name, dtype in npz["segments"].dtype.descr:
         # 'side' column added before 'position'
         if name == "position":
-            new_dtype.append(('side', 'U8'))
+            new_dtype.append(("side", "U8"))
             side_added = True
         new_dtype.append((name, dtype))
 
     if side_added is False:
-        new_dtype.append(('side', 'U8'))
+        new_dtype.append(("side", "U8"))
 
     segments = np.recarray(npz["segments"].shape, dtype=new_dtype)
 
     for name in npz["segments"].dtype.names:
         segments[name] = npz["segments"][name]
 
-    sides = np.full(segments.shape, None)  # start with None everywhere
+    sides = np.full(segments.shape, "", dtype="U8")  # start with empty strings
     sides[np.char.startswith(segments["position"], "r_")] = "right"
     sides[np.char.startswith(segments["position"], "l_")] = "left"
 


### PR DESCRIPTION
## Pull Request Overview

This PR adds functionality to include a 'side' column in segments data based on position prefixes. It addresses issue #18 by determining whether segments are left or right-sided based on their position field values.

- Adds a new function `add_side_column_to_segments` that determines side information from position prefixes
- Integrates the new functionality into the main download workflow by calling it in `download_npz`

New segments table (with side column)
<img width="1298" height="639" alt="Screenshot 2025-08-28 at 5 35 08 PM" src="https://github.com/user-attachments/assets/5438f16e-a640-43fb-bb26-571fc3b93600" />

Old segments table
<img width="1261" height="639" alt="Screenshot 2025-08-28 at 5 34 37 PM" src="https://github.com/user-attachments/assets/f334f1e3-b036-4991-8831-70d846592ca0" />
