### PR TITLE
Fix segment_num=0 being silently dropped in stream retrieval

### DIFF
--- a/cionic/npz_utils.py
+++ b/cionic/npz_utils.py
@@ -72,6 +72,8 @@ def retrieve_stream(
     Returns:
         np.recarray or None: The matched data segment if found, otherwise None.
     '''
+    if isinstance(segment_num, bool):
+        segment_num = None
     field_filters = {
         'position': position,
         'stream': stream,
@@ -102,7 +104,7 @@ def retrieve_stream_generalized(
     for field, value in field_filters.items():
         if field not in segments.dtype.names:
             raise ValueError(f"Warning: field '{field}' not in segments metadata.")
-        if value is not False and value is not None:
+        if value is not None:
             mask &= segments[field] == value
     filtered = segments[mask]
     if len(filtered) == 0:
@@ -135,6 +137,8 @@ def retrieve_segment_field(
     Returns:
         str, int, float, or None: The matched field value if found, otherwise None.
     '''
+    if isinstance(segment_num, bool):
+        segment_num = None
     for line in npz['segments.jsonl'].split(b'\n'):
         if line:
             segment = json.loads(line)

--- a/cionic/npz_utils.py
+++ b/cionic/npz_utils.py
@@ -101,7 +101,7 @@ def retrieve_stream_generalized(
     mask = np.ones(len(segments), dtype=bool)
     for field, value in field_filters.items():
         if field not in segments.dtype.names:
-            continue
+            raise ValueError(f"Warning: field '{field}' not in segments metadata.")
         if value is not False and value is not None:
             mask &= segments[field] == value
     filtered = segments[mask]

--- a/cionic/npz_utils.py
+++ b/cionic/npz_utils.py
@@ -76,7 +76,7 @@ def retrieve_stream(
         'position': position,
         'stream': stream,
     }
-    if segment_num:
+    if segment_num is not False:
         field_filters['segment_num'] = segment_num
     return retrieve_stream_generalized(npz=npz, field_filters=field_filters)
 
@@ -101,7 +101,7 @@ def retrieve_stream_generalized(
     mask = np.ones(len(segments), dtype=bool)
     for field, value in field_filters.items():
         if field not in segments.dtype.names:
-            raise ValueError(f"Warning: field '{field}' not in segments metadata.")
+            continue
         if value is not False and value is not None:
             mask &= segments[field] == value
     filtered = segments[mask]

--- a/cionic/npz_utils.py
+++ b/cionic/npz_utils.py
@@ -72,8 +72,6 @@ def retrieve_stream(
     Returns:
         np.recarray or None: The matched data segment if found, otherwise None.
     '''
-    if isinstance(segment_num, bool):
-        segment_num = None
     field_filters = {
         'position': position,
         'stream': stream,
@@ -137,8 +135,6 @@ def retrieve_segment_field(
     Returns:
         str, int, float, or None: The matched field value if found, otherwise None.
     '''
-    if isinstance(segment_num, bool):
-        segment_num = None
     for line in npz['segments.jsonl'].split(b'\n'):
         if line:
             segment = json.loads(line)

--- a/cionic/npz_utils.py
+++ b/cionic/npz_utils.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -57,7 +57,7 @@ def retrieve_stream(
     npz: np.lib.npyio.NpzFile,
     position: str,
     stream: str,
-    segment_num: Union[int, bool] = False,
+    segment_num: Optional[int] = None,
 ) -> Union[np.recarray, None]:
     '''
     Retrieve a specific data stream segment from an NPZ archive.
@@ -66,8 +66,8 @@ def retrieve_stream(
         npz (np.lib.npyio.NpzFile): Loaded NPZ archive.
         position (str): Position on body, e.g. "r_shank".
         stream (str): Stream name, e.g. "fquat".
-        segment_num (int or bool): Segment number to match in the segment metadata,
-            or False to ignore.
+        segment_num (Optional[int]): Segment number to match in the segment metadata,
+            or None to ignore.
 
     Returns:
         np.recarray or None: The matched data segment if found, otherwise None.
@@ -76,7 +76,7 @@ def retrieve_stream(
         'position': position,
         'stream': stream,
     }
-    if segment_num is not False:
+    if segment_num is not None:
         field_filters['segment_num'] = segment_num
     return retrieve_stream_generalized(npz=npz, field_filters=field_filters)
 
@@ -119,7 +119,7 @@ def retrieve_segment_field(
     position: str,
     stream: str,
     field_name: str,
-    segment_num: Union[int, bool] = False,
+    segment_num: Optional[int] = None,
 ) -> Union[str, int, float, None]:
     '''
     Retrieve a specific field from a line in the segments file in an NPZ archive.
@@ -129,8 +129,8 @@ def retrieve_segment_field(
         position (str): Position on body, e.g. "r_shank".
         stream (str): Stream name, e.g. "fquat".
         field_name (str): Name of the field to retrieve from the segment metadata.
-        segment_num (int or bool): Segment number to match in the segment metadata,
-            or False to ignore.
+        segment_num (Optional[int]): Segment number to match in the segment metadata,
+            or None to ignore.
 
     Returns:
         str, int, float, or None: The matched field value if found, otherwise None.
@@ -141,7 +141,7 @@ def retrieve_segment_field(
             if (
                 position == segment.get('position')
                 and stream == segment.get('stream')
-                and (segment_num is False or segment_num == segment.get('segment_num'))
+                and (segment_num is None or segment_num == segment.get('segment_num'))
             ):
                 return segment[field_name]
     return None

--- a/tests/test_npz_utils.py
+++ b/tests/test_npz_utils.py
@@ -13,6 +13,7 @@ based on specified field filters. The tests cover the following scenarios:
 - Ensuring that a `ValueError` is raised when an invalid field is specified.
 - Verifying that `segment_num=None` (the default) skips segment filtering.
 - Verifying that an explicit `segment_num` integer filters to the correct segment.
+- Verifying that `segment_num=0` is treated as a valid filter.
 
 Fixtures:
     npz: Loads the example NPZ file for use in the tests.
@@ -31,6 +32,8 @@ Test Cases:
     - test_retrieve_segment_field_with_segment_num: Returns field from matching segment.
     - test_retrieve_segment_field_none_returns_first_match: None skips segment filter.
     - test_retrieve_segment_field_default_is_none: Default kwarg behaves like None.
+    - test_retrieve_stream_segment_num_zero: segment_num=0 filters correctly.
+    - test_retrieve_segment_field_segment_num_zero: segment_num=0 returns correct field.
 """
 
 import io
@@ -58,19 +61,22 @@ def _npy_bytes(arr):
 @pytest.fixture(scope="module")
 def segmented_npz(tmp_path_factory):
     """
-    Minimal NPZ with two fquat segments for l_shank (segment_num 1 and 2).
+    Minimal NPZ with three fquat segments for l_shank (segment_num 0, 1, and 2).
 
-    Built via zipfile so that segments.jsonl is stored as raw bytes (matching
-    the real NPZ format) and stream data arrays are stored as .npy entries.
+    Segment 0 is included to ensure that segment_num=0 is treated as a valid filter.
+    Built via zipfile so that segments.jsonl is stored as raw bytes (matching the real
+    NPZ format) and stream data arrays are stored as .npy entries.
     """
     tmp = tmp_path_factory.mktemp("npz")
     path = str(tmp / "segmented.npz")
 
+    data_0 = np.zeros(10, dtype=np.float32)
     data_1 = np.ones(10, dtype=np.float32)
     data_2 = np.ones(10, dtype=np.float32) * 2
 
     segments = np.array(
         [
+            ("l_shank", "fquat", 0, "l_shank_fquat_0"),
             ("l_shank", "fquat", 1, "l_shank_fquat_1"),
             ("l_shank", "fquat", 2, "l_shank_fquat_2"),
         ],
@@ -83,6 +89,15 @@ def segmented_npz(tmp_path_factory):
     )
     jsonl = (
         json.dumps(
+            {
+                "position": "l_shank",
+                "stream": "fquat",
+                "segment_num": 0,
+                "device": "dev_zero",
+            }
+        )
+        + "\n"
+        + json.dumps(
             {
                 "position": "l_shank",
                 "stream": "fquat",
@@ -104,6 +119,7 @@ def segmented_npz(tmp_path_factory):
 
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("segments.npy", _npy_bytes(segments))
+        zf.writestr("l_shank_fquat_0.npy", _npy_bytes(data_0))
         zf.writestr("l_shank_fquat_1.npy", _npy_bytes(data_1))
         zf.writestr("l_shank_fquat_2.npy", _npy_bytes(data_2))
         zf.writestr("segments.jsonl", jsonl)  # raw bytes — no .npy magic prefix
@@ -214,7 +230,7 @@ def test_retrieve_segment_field_none_returns_first_match(segmented_npz):
         field_name="device",
         segment_num=None,
     )
-    assert device == "dev_a"
+    assert device == "dev_zero"
 
 
 def test_retrieve_segment_field_default_is_none(segmented_npz):
@@ -225,4 +241,30 @@ def test_retrieve_segment_field_default_is_none(segmented_npz):
         stream="fquat",
         field_name="device",
     )
-    assert device == "dev_a"
+    assert device == "dev_zero"
+
+
+# ---------------------------------------------------------------------------
+# Regression: segment_num=0 must not be dropped by a falsy check
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_stream_segment_num_zero(segmented_npz):
+    """segment_num=0 is a valid filter value and must not be treated as falsy."""
+    stream = npz_utils.retrieve_stream(
+        npz=segmented_npz, position="l_shank", stream="fquat", segment_num=0
+    )
+    assert stream is not None
+    assert np.all(stream == 0.0)
+
+
+def test_retrieve_segment_field_segment_num_zero(segmented_npz):
+    """segment_num=0 returns the correct field and must not be treated as falsy."""
+    device = npz_utils.retrieve_segment_field(
+        npz=segmented_npz,
+        position="l_shank",
+        stream="fquat",
+        field_name="device",
+        segment_num=0,
+    )
+    assert device == "dev_zero"

--- a/tests/test_npz_utils.py
+++ b/tests/test_npz_utils.py
@@ -1,7 +1,8 @@
 """
 Usage: pytest tests/test_npz_utils.py
 
-Unit tests for the `retrieve_stream_generalized` function in the `npz_utils` module.
+Unit tests for the `retrieve_stream_generalized`, `retrieve_stream`, and
+`retrieve_segment_field` functions in the `npz_utils` module.
 
 These tests verify the correct behavior of stream retrieval from an NPZ data source
 based on specified field filters. The tests cover the following scenarios:
@@ -10,16 +11,31 @@ based on specified field filters. The tests cover the following scenarios:
   the provided filters.
 - Confirming that the correct stream is returned when a single match is found.
 - Ensuring that a `ValueError` is raised when an invalid field is specified.
+- Verifying that `segment_num=None` (the default) skips segment filtering.
+- Verifying that an explicit `segment_num` integer filters to the correct segment.
 
 Fixtures:
     npz: Loads the example NPZ file for use in the tests.
+    segmented_npz: Minimal in-memory NPZ with two segments for testing segment_num
+        filtering in retrieve_stream and retrieve_segment_field.
 
 Test Cases:
     - test_multiple_streams_found: Checks error handling for multiple matching streams.
     - test_stream_found: Validates successful retrieval of a single matching stream.
     - test_bad_field_identified: Ensures that a `ValueError` is raised when an invalid
         field is specified.
+    - test_retrieve_stream_with_segment_num: Filters by segment_num and
+        returns correct data.
+    - test_retrieve_stream_none_raises_when_ambiguous: segment_num=None skips filter.
+    - test_retrieve_stream_default_is_none: Default kwarg behaves like segment_num=None.
+    - test_retrieve_segment_field_with_segment_num: Returns field from matching segment.
+    - test_retrieve_segment_field_none_returns_first_match: None skips segment filter.
+    - test_retrieve_segment_field_default_is_none: Default kwarg behaves like None.
 """
+
+import io
+import json
+import zipfile
 
 import numpy as np
 import pytest
@@ -30,6 +46,69 @@ from cionic import npz_utils
 @pytest.fixture(scope="module")
 def npz():
     return np.load("npz_examples/example.npz")
+
+
+def _npy_bytes(arr):
+    """Serialize a numpy array to .npy-format bytes."""
+    buf = io.BytesIO()
+    np.save(buf, arr)
+    return buf.getvalue()
+
+
+@pytest.fixture(scope="module")
+def segmented_npz(tmp_path_factory):
+    """
+    Minimal NPZ with two fquat segments for l_shank (segment_num 1 and 2).
+
+    Built via zipfile so that segments.jsonl is stored as raw bytes (matching
+    the real NPZ format) and stream data arrays are stored as .npy entries.
+    """
+    tmp = tmp_path_factory.mktemp("npz")
+    path = str(tmp / "segmented.npz")
+
+    data_1 = np.ones(10, dtype=np.float32)
+    data_2 = np.ones(10, dtype=np.float32) * 2
+
+    segments = np.array(
+        [
+            ("l_shank", "fquat", 1, "l_shank_fquat_1"),
+            ("l_shank", "fquat", 2, "l_shank_fquat_2"),
+        ],
+        dtype=[
+            ("position", "<U20"),
+            ("stream", "<U16"),
+            ("segment_num", "<i4"),
+            ("path", "<U32"),
+        ],
+    )
+    jsonl = (
+        json.dumps(
+            {
+                "position": "l_shank",
+                "stream": "fquat",
+                "segment_num": 1,
+                "device": "dev_a",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "position": "l_shank",
+                "stream": "fquat",
+                "segment_num": 2,
+                "device": "dev_b",
+            }
+        )
+        + "\n"
+    ).encode()
+
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("segments.npy", _npy_bytes(segments))
+        zf.writestr("l_shank_fquat_1.npy", _npy_bytes(data_1))
+        zf.writestr("l_shank_fquat_2.npy", _npy_bytes(data_2))
+        zf.writestr("segments.jsonl", jsonl)  # raw bytes — no .npy magic prefix
+
+    return np.load(path)
 
 
 def test_multiple_streams_found(npz):
@@ -79,3 +158,71 @@ def test_bad_field_identified(npz):
     field_filters = {"position": "l_shank", "stream": "euler", "invalid_field": "value"}
     with pytest.raises(ValueError):
         npz_utils.retrieve_stream_generalized(npz=npz, field_filters=field_filters)
+
+
+# ---------------------------------------------------------------------------
+# retrieve_stream — segment_num sentinel tests
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_stream_with_segment_num(segmented_npz):
+    """Passing a specific segment_num returns only that segment's data."""
+    stream = npz_utils.retrieve_stream(
+        npz=segmented_npz, position="l_shank", stream="fquat", segment_num=1
+    )
+    assert stream is not None
+    assert np.all(stream == 1.0)
+
+
+def test_retrieve_stream_none_raises_when_ambiguous(segmented_npz):
+    """segment_num=None skips the filter, so two matching segments → error."""
+    with pytest.raises(npz_utils.MultipleStreamsFoundError):
+        npz_utils.retrieve_stream(
+            npz=segmented_npz, position="l_shank", stream="fquat", segment_num=None
+        )
+
+
+def test_retrieve_stream_default_is_none(segmented_npz):
+    """Omitting segment_num behaves identically to segment_num=None."""
+    with pytest.raises(npz_utils.MultipleStreamsFoundError):
+        npz_utils.retrieve_stream(npz=segmented_npz, position="l_shank", stream="fquat")
+
+
+# ---------------------------------------------------------------------------
+# retrieve_segment_field — segment_num sentinel tests
+# ---------------------------------------------------------------------------
+
+
+def test_retrieve_segment_field_with_segment_num(segmented_npz):
+    """Passing segment_num returns the field value from the matching segment only."""
+    device = npz_utils.retrieve_segment_field(
+        npz=segmented_npz,
+        position="l_shank",
+        stream="fquat",
+        field_name="device",
+        segment_num=1,
+    )
+    assert device == "dev_a"
+
+
+def test_retrieve_segment_field_none_returns_first_match(segmented_npz):
+    """segment_num=None ignores segment filtering and returns the first match."""
+    device = npz_utils.retrieve_segment_field(
+        npz=segmented_npz,
+        position="l_shank",
+        stream="fquat",
+        field_name="device",
+        segment_num=None,
+    )
+    assert device == "dev_a"
+
+
+def test_retrieve_segment_field_default_is_none(segmented_npz):
+    """Omitting segment_num behaves identically to segment_num=None."""
+    device = npz_utils.retrieve_segment_field(
+        npz=segmented_npz,
+        position="l_shank",
+        stream="fquat",
+        field_name="device",
+    )
+    assert device == "dev_a"


### PR DESCRIPTION
Use `is not None` check so falsy-but-valid values like 0 are included in field filters.